### PR TITLE
Remove null test from object test - comports with JS instanceof.

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -77,7 +77,7 @@ namespace.module('firebase.rules.ast', function(exports, require) {
 
   function snapshotChild(base, accessor) {
     if (typeof accessor == 'string') {
-      accessor = string(accessor);
+      accessor = exports.string(accessor);
     }
     var result = call(reference(base, 'child'), [accessor]);
     result.valueType = 'snapshot';
@@ -95,7 +95,7 @@ namespace.module('firebase.rules.ast', function(exports, require) {
   function ensureBoolean(exp) {
     exp = ensureValue(exp);
     if (isCall(exp, 'val')) {
-      exp = exports.eq(exp, boolean(true));
+      exp = exports.eq(exp, exports.boolean(true));
     }
     return exp;
   }
@@ -107,10 +107,6 @@ namespace.module('firebase.rules.ast', function(exports, require) {
   function snapshotValue(exp) {
     return call(reference(exp, 'val'), []);
   }
-
-  var number = valueGen('number');
-  var boolean = valueGen('boolean');
-  var string = valueGen('string');
 
   function valueGen(type) {
     return function(value) {
@@ -194,6 +190,26 @@ namespace.module('firebase.rules.ast', function(exports, require) {
       };
       this.register('schema', name, s);
     },
+
+    isDerivedFrom: function(descendant, ancestor, visited) {
+      if (!visited) {
+        visited = {};
+      }
+      if (visited[descendant]) {
+        return false;
+      }
+      visited[descendant] = true;
+
+      if (descendant == ancestor) {
+        return true;
+      }
+
+      var schema = this.schema[descendant];
+      if (!schema) {
+        return false;
+      }
+      return this.isDerivedFrom(schema.derivedFrom, ancestor, visited);
+    }
   });
 
 });

--- a/lib/rules-generator.js
+++ b/lib/rules-generator.js
@@ -10,6 +10,15 @@ namespace.module('firebase.rules.generator', function(exports, require) {
     'decodeExpression': decodeExpression
   });
 
+  var errors = {
+    badIndex: "Index function must return (an array of) string(s).",
+    noPaths: "Must have at least one path expression.",
+    nonObject: "Type contains properties and must extend 'object'.",
+    missingSchema: "Missing definition for type.",
+    recursive: "Recursive function call.",
+    mismatchParams: "Incorrect number of function arguments.",
+  };
+
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence
   var JS_OPS = {
     "neg": { rep: "-", p: 15},
@@ -64,7 +73,7 @@ namespace.module('firebase.rules.generator', function(exports, require) {
       var paths = this.symbols.paths;
 
       if (Object.keys(paths).length === 0) {
-        throw new Error("Must have at least one path expression.");
+        throw new Error(errors.noPaths);
       }
 
       for (var pathName in paths) {
@@ -83,9 +92,7 @@ namespace.module('firebase.rules.generator', function(exports, require) {
       // TODO: These functions are value-creating...should remove "snapshot" of parameter.
 
       // this.hasChildren()
-      // TODO: should this be this == null || this.hasChildren()???
-      this.registerValidator('object', ast.or(ast.eq(thisVar, ast.nullType()),
-                                              ast.call(ast.reference(thisVar, 'hasChildren'), [])));
+      this.registerValidator('object', ast.call(ast.reference(thisVar, 'hasChildren'), []));
       // this.isString()
       this.registerValidator('string', ast.call(ast.reference(thisVar, 'isString'), []));
       // this.isNumber()
@@ -98,7 +105,7 @@ namespace.module('firebase.rules.generator', function(exports, require) {
 
     // Return a validator expression that returns true iff
     // *this* conforms to the defined schema:
-    // 1. Conforms to derivedFrom schema.
+    // 1. Conforms to derivedFrom schema. &&
     // 2. Each property in properties conforms to it's type.
     // 3. Conforms to the validate method.
     registerSchemaValidator: function(schemaName) {
@@ -106,9 +113,17 @@ namespace.module('firebase.rules.generator', function(exports, require) {
       var terms = [];
       var thisVar = ast.variable('this');
 
+      var hasProps = Object.keys(schema.properties).length > 0;
+
       // @validator@<T>(this)
-      terms.push(ast.call(ast.variable('@validator@' + schema.derivedFrom),
-                          [ thisVar ]));
+      if (schema.derivedFrom != 'object' || !hasProps) {
+        terms.push(ast.call(ast.variable('@validator@' + schema.derivedFrom),
+                            [ thisVar ]));
+      }
+
+      if (hasProps && !this.symbols.isDerivedFrom(schemaName, 'object')) {
+        throw new Error(errors.nonObject + " (" + schemaName + ")");
+      }
 
       for (var propName in schema.properties) {
         var property = schema.properties[propName];
@@ -132,6 +147,7 @@ namespace.module('firebase.rules.generator', function(exports, require) {
       this.registerValidator(schemaName, result);
     },
 
+    // TODO: Should validators be functions stored in a schema?
     registerValidator: function(type, exp) {
       this.symbols.registerFunction('@validator@' + type, ['this'], exp);
     },
@@ -143,20 +159,24 @@ namespace.module('firebase.rules.generator', function(exports, require) {
       var location = this.ensurePath(path.parts);
 
       for (i = 0; i < pathMethods.length; i++) {
-        if (path.methods[pathMethods[i]]) {
-          location['.' + pathMethods[i]] = this.getExpressionText(path.methods[pathMethods[i]].body);
+        var method = pathMethods[i];
+        if (path.methods[method]) {
+          location['.' + method] = this.getExpressionText(path.methods[method].body);
         }
       }
 
       if (path.methods.index) {
         var exp = path.methods.index.body;
+        if (exp.type == 'string') {
+          exp = ast.array([exp]);
+        }
         if (exp.type != 'array') {
-          throw new Error("index function must return an array of (string) indices.");
+          throw new Error(errors.badIndex);
         }
         var indices = [];
         for (i = 0; i < exp.value.length; i++) {
           if (exp.value[i].type != 'string') {
-            throw new Error("index function must return an array of (string) indices (not " + exp.value[i].type + ").");
+            throw new Error(errors.badIndex + " (not " + exp.value[i].type + ")");
           }
           indices.push(exp.value[i].value);
         }
@@ -242,7 +262,7 @@ namespace.module('firebase.rules.generator', function(exports, require) {
         if (exp.op == 'instanceof') {
           var dataType = exp.args[1];
           if (dataType.type != 'var' || !this.symbols.schema[dataType.name]) {
-            throw new Error("Missing definition for schema: " + dataType.name);
+            throw new Error(errors.missingType + " (" + dataType.name + ")");
           }
           innerParams['this'] = subExpression(exp.args[0]);
           // TODO: Do as call - to get arg checking on expansion...
@@ -303,12 +323,12 @@ namespace.module('firebase.rules.generator', function(exports, require) {
         var fn = this.lookupFunction(ref);
         if (fn) {
           if (functionCalls[ref.name]) {
-            throw new Error("Recursive function call to " + ref.name);
+            throw new Error(errors.recursive + " (" + ref.name + ")");
           }
           if (fn.params.length != exp.args.length) {
-            throw new Error("Incorrect number of function arguments.  " +
+            throw new Error(errors.mismatchParams + " ( " +
                             ref.name + " expects " + fn.params.length +
-                            "but actually passed " + exp.args.length + ".");
+                            "but actually passed " + exp.args.length + ")");
           }
           for (i = 0; i < fn.params.length; i++) {
             innerParams[fn.params[i]] = subExpression(exp.args[i]);

--- a/test/samples/mail.json
+++ b/test/samples/mail.json
@@ -6,14 +6,14 @@
           "$msg": {
             ".read": "auth.username == $userid",
             ".write": "data.val() == null || data.val() != null && auth.username == $userid",
-            ".validate": "(newData.val() == null || newData.hasChildren()) && newData.child('from').isString() && newData.child('to').isString() && newData.child('message').isString() && auth.username == newData.child('from').val()"
+            ".validate": "newData.child('from').isString() && newData.child('to').isString() && newData.child('message').isString() && auth.username == newData.child('from').val()"
           }
         },
         "outbox": {
           "$msg": {
             ".read": "auth.username == $userid",
             ".write": "data.val() == null || data.val() != null && auth.username == $userid",
-            ".validate": "(newData.val() == null || newData.hasChildren()) && newData.child('from').isString() && newData.child('to').isString() && newData.child('message').isString() && auth.username == newData.child('from').val()"
+            ".validate": "newData.child('from').isString() && newData.child('to').isString() && newData.child('message').isString() && auth.username == newData.child('from').val()"
           }
         }
       }

--- a/test/samples/userdoc.json
+++ b/test/samples/userdoc.json
@@ -5,7 +5,7 @@
         "$docid": {
           ".read": "auth.uid == $userid || root.child('permissions').child(auth.uid + '|' + $docid).child('read').val() == true",
           ".write": "auth.uid == $userid || root.child('permissions').child(auth.uid + '|' + $docid).child('write').val() == true",
-          ".validate": "newData.val() == null || newData.hasChildren()"
+          ".validate": "newData.hasChildren()"
         }
       }
     },
@@ -15,7 +15,7 @@
         "$docid": {
           ".read": "root.child('permissions').child(auth.uid + '|' + $docid).child('read').val() == true",
           ".write": "auth.uid == $userid || root.child('permissions').child(auth.uid + '|' + $docid).child('write').val() == true",
-          ".validate": "(newData.val() == null || newData.hasChildren()) && newData.child('created').isString() && newData.child('modified').isString() && newData.child('title').isString()"
+          ".validate": "newData.child('created').isString() && newData.child('modified').isString() && newData.child('title').isString()"
         }
       }
     },
@@ -28,7 +28,7 @@
       ],
       "$key": {
         ".write": "newData.val() == null && auth.uid == data.child('grantor').val() || newData.val() != null && root.child('documents').child(auth.uid).child(newData.child('docid').val()).val() != null",
-        ".validate": "(newData.val() == null || newData.hasChildren()) && newData.child('grantor').isString() && newData.child('grantee').isString() && newData.child('docid').isString() && $key == newData.child('grantee').val() + '|' + newData.child('docid').val() && newData.child('grantor').val() == auth.uid"
+        ".validate": "newData.child('grantor').isString() && newData.child('grantee').isString() && newData.child('docid').isString() && $key == newData.child('grantee').val() + '|' + newData.child('docid').val() && newData.child('grantor').val() == auth.uid"
       }
     }
   }


### PR DESCRIPTION
@tomlarkworthy 

This change simplifies redundant expressions in rules output as well as matching how JS instanceof works.  Note that validate rules never need this.val() == null; and in write rules, most likely there need not be instanceof validation - just checks for null or not (passed on authentication state).
