### PR TITLE
Constrain type names to use initial capitals.

### DIFF
--- a/docs/language.md
+++ b/docs/language.md
@@ -86,10 +86,10 @@ a Type or path storage location.
 
 Built in base types are also similar to JavaScript types:
 
-    string
-    number - integer of floating point
-    boolean - true or false
-    object - A structured object containing named properties.
+    String
+    Number - integer of floating point
+    Boolean - true or false
+    Object - A structured object containing named properties.
 
 # Expressions
 

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -19,9 +19,9 @@
 
 var util = require('./util');
 
-var string = valueGen('string');
+var string = valueGen('String');
 var eq = opGen('==');
-var boolean = valueGen('boolean');
+var boolean = valueGen('Boolean');
 
 module.exports = {
   'variable': variable,
@@ -34,7 +34,7 @@ module.exports = {
   'ensureValue': ensureValue,
   'ensureBoolean': ensureBoolean,
 
-  'number': valueGen('number'),
+  'number': valueGen('Number'),
   'boolean': boolean,
   'string': string,
   'array': array,
@@ -70,7 +70,7 @@ function variable(name) {
 }
 
 function nullType() {
-  return { type: 'null' };
+  return { type: 'Null' };
 }
 
 function reference(base, prop) {
@@ -87,7 +87,7 @@ function call(ref, args) {
 
 function snapshotVariable(name) {
   var result = variable(name);
-  result.valueType = 'snapshot';
+  result.valueType = 'Snapshot';
   return result;
 }
 
@@ -96,12 +96,12 @@ function snapshotChild(base, accessor) {
     accessor = string(accessor);
   }
   var result = call(reference(base, 'child'), [accessor]);
-  result.valueType = 'snapshot';
+  result.valueType = 'Snapshot';
   return result;
 }
 
 function ensureValue(exp) {
-  if (exp.valueType == 'snapshot') {
+  if (exp.valueType == 'Snapshot') {
     return snapshotValue(exp);
   }
   return exp;
@@ -162,7 +162,7 @@ function op(opType, args) {
 }
 
 function array(args) {
-  return { type: 'array', value: args };
+  return { type: 'Array', value: args };
 }
 
 function Symbols() {
@@ -201,7 +201,7 @@ util.methods(Symbols, {
 
   registerSchema: function(name, derivedFrom, properties, methods) {
     var s = {
-      derivedFrom: derivedFrom || 'object',
+      derivedFrom: derivedFrom || 'Object',
       properties: properties,
       methods: methods
     };

--- a/lib/rules-generator.js
+++ b/lib/rules-generator.js
@@ -114,15 +114,15 @@ methods(Generator, {
     // TODO: These functions are value-creating...should remove "snapshot" of parameter.
 
     // this.hasChildren()
-    this.registerValidator('object', ast.call(ast.reference(thisVar, 'hasChildren'), []));
+    this.registerValidator('Object', ast.call(ast.reference(thisVar, 'hasChildren'), []));
     // this.isString()
-    this.registerValidator('string', ast.call(ast.reference(thisVar, 'isString'), []));
+    this.registerValidator('String', ast.call(ast.reference(thisVar, 'isString'), []));
     // this.isNumber()
-    this.registerValidator('number', ast.call(ast.reference(thisVar, 'isNumber'), []));
+    this.registerValidator('Number', ast.call(ast.reference(thisVar, 'isNumber'), []));
     // this.isBoolean()
-    this.registerValidator('boolean', ast.call(ast.reference(thisVar, 'isBoolean'), []));
+    this.registerValidator('Boolean', ast.call(ast.reference(thisVar, 'isBoolean'), []));
     // this == null
-    this.registerValidator('null', ast.eq(thisVar, ast.nullType()));
+    this.registerValidator('Null', ast.eq(thisVar, ast.nullType()));
   },
 
   // Return a validator expression that returns true iff
@@ -138,12 +138,12 @@ methods(Generator, {
     var hasProps = Object.keys(schema.properties).length > 0;
 
     // @validator@<T>(this)
-    if (schema.derivedFrom != 'object' || !hasProps) {
+    if (schema.derivedFrom != 'Object' || !hasProps) {
       terms.push(ast.call(ast.variable('@validator@' + schema.derivedFrom),
                           [ thisVar ]));
     }
 
-    if (hasProps && !this.symbols.isDerivedFrom(schemaName, 'object')) {
+    if (hasProps && !this.symbols.isDerivedFrom(schemaName, 'Object')) {
       throw new Error(errors.nonObject + " (" + schemaName + ")");
     }
 
@@ -189,15 +189,15 @@ methods(Generator, {
 
     if (path.methods.index) {
       var exp = path.methods.index.body;
-      if (exp.type == 'string') {
+      if (exp.type == 'String') {
         exp = ast.array([exp]);
       }
-      if (exp.type != 'array') {
+      if (exp.type != 'Array') {
         throw new Error(errors.badIndex);
       }
       var indices = [];
       for (i = 0; i < exp.value.length; i++) {
-        if (exp.value[i].type != 'string') {
+        if (exp.value[i].type != 'String') {
           throw new Error(errors.badIndex + " (not " + exp.value[i].type + ")");
         }
         indices.push(exp.value[i].value);
@@ -255,14 +255,14 @@ methods(Generator, {
     }
 
     function valueExpression(exp2) {
-      if (exp2.valueType == 'snapshot') {
+      if (exp2.valueType == 'Snapshot') {
         isModified = true;
       }
       return ast.ensureValue(exp2);
     }
 
     function booleanExpression(exp2) {
-      if (exp2.valueType == 'snapshot') {
+      if (exp2.valueType == 'Snapshot') {
         isModified = true;
       }
       return ast.ensureBoolean(exp2);
@@ -330,7 +330,7 @@ methods(Generator, {
       // snapshot references use child() wrapper - EXCEPT for built-in methods
       // TODO: Resolve ambiguity between built-ins and user-defined property names
       // (use functions instead)?
-      if (base.valueType == 'snapshot' && snapshotMethods.indexOf(accessor) == -1) {
+      if (base.valueType == 'Snapshot' && snapshotMethods.indexOf(accessor) == -1) {
         exp = ast.snapshotChild(base, accessor);
       } else {
         if (replaceExp()) {
@@ -412,16 +412,16 @@ function decodeExpression(exp, outerPrecedence) {
   var innerPrecedence = precedenceOf(exp);
   var result;
   switch (exp.type) {
-  case 'boolean':
-  case 'number':
+  case 'Boolean':
+  case 'Number':
     result = JSON.stringify(exp.value);
     break;
 
-  case 'string':
+  case 'String':
     result = quoteString(exp.value);
     break;
 
-  case 'null':
+  case 'Null':
     result = 'null';
     break;
 
@@ -462,7 +462,7 @@ function decodeExpression(exp, outerPrecedence) {
     }
     break;
 
-  case 'array':
+  case 'Array':
     result = '[' + decodeArray(exp.value) + ']';
     break;
 

--- a/src/rules-parser.pegjs
+++ b/src/rules-parser.pegjs
@@ -37,7 +37,7 @@
     if (s != canonical) {
       warn(m + " should begin with a lowercase letter: ('" + s + "' should be '" + canonical + "').");
     }
-    return canonical;
+    return s;
   }
 
   function ensureUpperCase(s, m) {
@@ -45,7 +45,7 @@
     if (s != canonical) {
       warn(m + " should begin with an uppercase letter: ('" + s + "' should be '" + canonical + "').");
     }
-    return canonical;
+    return s;
   }
 
   function warn(s) {

--- a/src/rules-parser.pegjs
+++ b/src/rules-parser.pegjs
@@ -31,6 +31,30 @@
   }
 
   var symbols = new ast.Symbols();
+
+  function ensureLowerCase(s, m) {
+    var canonical = s[0].toLowerCase() + s.slice(1);
+    if (s != canonical) {
+      warn(m + " should begin with a lowercase letter: ('" + s + "' should be '" + canonical + "').");
+    }
+    return canonical;
+  }
+
+  function ensureUpperCase(s, m) {
+    var canonical = s[0].toUpperCase() + s.slice(1);
+    if (s != canonical) {
+      warn(m + " should begin with an uppercase letter: ('" + s + "' should be '" + canonical + "').");
+    }
+    return canonical;
+  }
+
+  function warn(s) {
+    console.warn(errorString({line: line(), column: column()}, s));
+  }
+
+  function errorString(loc, s) {
+    return 'bolt:' + loc.line + ':' + loc.column + ': ' + s;
+  }
 }
 
 start = _ rules:Rules _ {
@@ -46,12 +70,12 @@ Rule = f:Function { symbols.registerFunction(f.name, f.params, f.body); }
 Function = "function" __ name:Identifier params:ParameterList "{" _
   body:FunctionBody _
   "}" {
-  return {
-    name: name,
-    params: params,
-    body: body
-  };
-}
+    return {
+      name: ensureLowerCase(name, "Function names"),
+      params: params,
+      body: body
+    };
+  }
 
 Path = "path" __ path:PathExpression _ "{" _ methods:Methods _ "}" {
   return {
@@ -70,11 +94,11 @@ PathExpression = "/" Whitespace {
   }
 
 Schema =
-  "type" __ id:Identifier _ derived:("extends" __ Identifier _)? "{" _
+  "type" __ type:Identifier _ derived:("extends" __ Identifier _)? "{" _
   properties:Properties?
   "}" {
     var result = {
-      name: id,
+      name: ensureUpperCase(type, "Type names"),
       methods: {},
       properties: {}
     };
@@ -83,7 +107,7 @@ Schema =
       result.properties = properties.properties;
     }
     if (derived) {
-      result.derivedFrom = derived[2];
+      result.derivedFrom = ensureUpperCase(derived[2], "Type names");
     }
     return result;
 }
@@ -95,9 +119,10 @@ Properties = head:PropertyDefinition tail:(_ ","? _ part:PropertyDefinition { re
   };
 
   function addPart(part) {
+    // TODO: Make sure methods and properties don't shadow each other.
     if ('types' in part) {
       if (result.properties[part.name]) {
-        error("Duplicate propert name: " + part.name);
+        error("Duplicate property name: " + part.name);
       }
       result.properties[part.name] = {
         types: part.types
@@ -147,7 +172,7 @@ Methods = all:(Method _)* {
 Method = name:Identifier params:ParameterList
     "{" _ body:FunctionBody _ "}" {
       return {
-        name:  name,
+        name:  ensureLowerCase(name, "Method names"),
         params: params,
         body:  body
       };
@@ -163,7 +188,7 @@ ParameterList = "(" _ ")" _ {
   / "(" _ head:Identifier tail:(_ "," _ Identifier)* _ ")" _ {
     var result = [head];
     for (var i = 0; i < tail.length; i++) {
-      result.push(tail[i][3]);
+      result.push(ensureLowerCase(tail[i][3], "Function arguments"));
     }
     return result;
 }
@@ -172,9 +197,9 @@ ParameterList = "(" _ ")" _ {
 // TODO: Allow for generic types, e.g., Type<A, B>
 TypeExpression "type" =
   head:Identifier tail:(_ "|" _ id:Identifier { return id; } )* _{
-    var result = [head];
+    var result = [ensureUpperCase(head, "Type names")];
     for (var i = 0; i < tail.length; i++) {
-      result.push(tail[i]);
+      result.push(ensureUpperCase(tail[i], "Type names"));
     }
     return result;
   }

--- a/test/generator-test.js
+++ b/test/generator-test.js
@@ -240,11 +240,11 @@ path /x { read() { return " + tests[i].x + "; }}\
   test("Builtin validation functions", function() {
     var symbols = parse("");
     var gen = new bolt.Generator(symbols);
-    var baseTypes = ['string', 'number', 'boolean'];
-    assert.equal(gen.getExpressionText(symbols.functions['@validator@object'].body),
-                 'newData.hasChildren()', 'object');
-    assert.equal(gen.getExpressionText(symbols.functions['@validator@null'].body),
-                 'newData.val() == null', 'object');
+    var baseTypes = ['String', 'Number', 'Boolean'];
+    assert.equal(gen.getExpressionText(symbols.functions['@validator@Object'].body),
+                 'newData.hasChildren()', 'Object');
+    assert.equal(gen.getExpressionText(symbols.functions['@validator@Null'].body),
+                 'newData.val() == null', 'Object');
     for (var i = 0; i < baseTypes.length; i++) {
       var type = baseTypes[i];
       assert.equal(gen.getExpressionText(symbols.functions['@validator@' + type].body),
@@ -256,22 +256,22 @@ path /x { read() { return " + tests[i].x + "; }}\
     var tests = [
       { s: "type Simple {}", v: "this instanceof Simple",
         x: "newData.hasChildren()" },
-      { s: "type Simple extends string {}", v: "this instanceof Simple", x: "newData.isString()" },
-      { s: "type Simple {n: number}", v: "this instanceof Simple",
+      { s: "type Simple extends String {}", v: "this instanceof Simple", x: "newData.isString()" },
+      { s: "type Simple {n: Number}", v: "this instanceof Simple",
         x: "newData.child('n').isNumber()" },
-      { s: "type Simple {s: string}", v: "this instanceof Simple",
+      { s: "type Simple {s: String}", v: "this instanceof Simple",
         x: "newData.child('s').isString()" },
-      { s: "type Simple {b: boolean}", v: "this instanceof Simple",
+      { s: "type Simple {b: Boolean}", v: "this instanceof Simple",
         x: "newData.child('b').isBoolean()" },
-      { s: "type Simple {x: object}", v: "this instanceof Simple",
+      { s: "type Simple {x: Object}", v: "this instanceof Simple",
         x: "newData.child('x').hasChildren()" },
-      { s: "type Simple {x: number|string}", v: "this instanceof Simple",
+      { s: "type Simple {x: Number|String}", v: "this instanceof Simple",
         x: "newData.child('x').isNumber() || newData.child('x').isString()" },
-      { s: "type Simple {a: number, b: string}", v: "this instanceof Simple",
+      { s: "type Simple {a: Number, b: String}", v: "this instanceof Simple",
         x: "newData.child('a').isNumber() && newData.child('b').isString()" },
-      { s: "type Simple {x: number|null}", v: "this instanceof Simple",
+      { s: "type Simple {x: Number|Null}", v: "this instanceof Simple",
         x: "newData.child('x').isNumber() || newData.child('x').val() == null" },
-      { s: "type Simple {n: number, validate() {return this.n < 7;}}", v: "this instanceof Simple",
+      { s: "type Simple {n: Number, validate() {return this.n < 7;}}", v: "this instanceof Simple",
         x: "newData.child('n').isNumber() && newData.child('n').val() < 7" },
     ];
     for (var i = 0; i < tests.length; i++) {
@@ -286,7 +286,7 @@ path /x { read() { return " + tests[i].x + "; }}\
     var tests = [
       { s: "",
         e: "at least one path" },
-      { s: "type Simple extends string {a: string} path /x {} ",
+      { s: "type Simple extends String {a: String} path /x {} ",
         e: /properties.*extend/ },
       { s: "path /y { index() { return 1; }}",
         e: /index.*string/i },

--- a/test/parser-test.js
+++ b/test/parser-test.js
@@ -32,7 +32,7 @@ function fnAST() {
   return {
     params: [],
     body: {
-      type: 'boolean',
+      type: 'Boolean',
       value: true
     }
   };
@@ -44,10 +44,10 @@ var pathAST = {
   methods: {}
 };
 
-var schema = "type Foo { a: number }";
+var schema = "type Foo { a: Number }";
 var schemaAST = {
-  derivedFrom: 'object',
-  properties: { "a": { types: ['number'] } },
+  derivedFrom: 'Object',
+  properties: { "a": { types: ['Number'] } },
   methods: {}
 };
 
@@ -71,7 +71,7 @@ suite("Rules Parser Tests", function() {
     assert.deepEqual(result.functions.longName, {
       params: [],
       body: {
-        type: "boolean",
+        type: "Boolean",
         value: false
       }
     });
@@ -218,15 +218,15 @@ suite("Rules Parser Tests", function() {
   test("Multiprop Schema", function() {
     var result = parse("\
 type Multi {\
-a: number,\
-b: string\
+a: Number,\
+b: String\
 }\
 ");
     assert.deepEqual(result.schema.Multi, {
-      derivedFrom: 'object',
+      derivedFrom: 'Object',
       properties: {
-        "a": { types: ['number'] },
-        "b": { types: ['string'] }
+        "a": { types: ['Number'] },
+        "b": { types: ['String'] }
       },
       methods: {}
     });
@@ -245,20 +245,20 @@ b: string\
     var result = parse("\
 type Foo {\
 \
-a: number,\
+a: Number,\
 \
 validate() {\
 return true;\
 }\
 }");
     assert.deepEqual(result.schema.Foo, {
-      derivedFrom: 'object',
-      properties: { "a": { types: ['number'] }},
+      derivedFrom: 'Object',
+      properties: { "a": { types: ['Number'] }},
       methods: {
         "validate": {
           params: [],
           body: {
-            type: "boolean",
+            type: "Boolean",
             value: true
           }
         }
@@ -280,7 +280,7 @@ return true;\
         validate: {
           params: [],
           body: {
-            type: "boolean",
+            type: "Boolean",
             value: true
           }
         }

--- a/test/samples/mail.bolt
+++ b/test/samples/mail.bolt
@@ -2,9 +2,9 @@
 // https://github.com/firebase/blaze_compiler/blob/master/examples/mail_example.yaml
 
 type Message {
-  from: string
-  to: string
-  message: string
+  from: String
+  to: String
+  message: String
 
   validate() {
     return isCurrentUser(this.from);

--- a/test/samples/userdoc.bolt
+++ b/test/samples/userdoc.bolt
@@ -1,21 +1,21 @@
 // Rules defined using new Rules Engine syntax.
 
-type Document extends object {}
+type Document extends Object {}
 
-type Date extends string {
+type Date extends String {
   // validate() { return isISODate(this); }
 }
 
-type Userid extends string {
+type Userid extends String {
   // validate() { return userExists(this); }
 }
 
-type Docid extends string {}
+type Docid extends String {}
 
 type Metadata {
   created: Date,
   modified: Date,
-  title: string,
+  title: String,
 
   extensible(prop) { return true; }
 }


### PR DESCRIPTION
@tomlarkworthy 

I changed the parser to enforce these rules:

- Type names must begin with an initial capital letter.
- Functions and method names (and function formal parameters), but begin with an initial lowercase letter.

Internal names for builtin types, also changed to be initial capital for consistency.

I chose to auto-convert invalid uses, but send a warning to the terminal for each instance so the developer can correct them (but parsing continues for the whole file make a best-effort).