### PR TITLE
Remove instanceof and add path /... is Type.

### DIFF
--- a/docs/language.md
+++ b/docs/language.md
@@ -30,23 +30,11 @@ A bolt file can also contain JavaScript-style comments:
        comment
     */
 
-# Functions
-
-Functions must be simple return expressions with zero or more parameters.
-
-    function myFunction(arg1, arg2) {
-      return arg1 == arg2.value;
-    }
-
 # Paths
 
 A path statement provides access and validation rules for data stored at a given path.
 
-    path /path/to/data {
-      validate() {
-        return <validation expression>;
-      }
-
+    path /path/to/data [is Type] {
       read() {
         return <true-iff-reading-this-location-is-allowed>;
       }
@@ -56,17 +44,19 @@ A path statement provides access and validation rules for data stored at a given
       }
     }
 
+If a Type is not given, `Any` is assumed.
+
 Path statements can also include wildcards parts whose values can then be used
 within an expression as a variable parameter.
 
-    path /top/$wildcard/$id {
-      validate() {
+    path /top/$wildcard/$id is Type {
+      write() {
         return $wildcard < "Z" && $id > 7;
       }
     }
 
-In expressions, the value of 'this' is defined to be the top level object when used in
-a Type or path storage location.
+In expressions, the value of `this` is defined to be *new* value at the path location (i.e.
+if writing, it is the value at the location after the write would have been complete).
 
 # Types
 
@@ -78,22 +68,48 @@ a Type or path storage location.
       validate() {
         return <validation expression>;
       }
-
-      extensible(propertyName) {
-        return <propery extension allow if true>;
-      }
     }
+
+The value of `this` is the object of type TypeName (so properties can be referenced
+in expressions as `this.property`).
+
+If a BaseType is not given, `Object` is assumed if the TypeName has child properties
+(`Any` if not).
 
 Built in base types are also similar to JavaScript types:
 
-    String
-    Number - integer of floating point
+    String  -
+    Number  - integer or floating point
     Boolean - true or false
-    Object - A structured object containing named properties.
+    Object  - A structured object containing named properties.
+    Null    - null (absence of a value, or deleted)
+    Any     - Matches any of the other types.
+
+# Global variables
+
+You can also use:
+
+    data - The value at a location BEFORE a write is done.
+    root - The root of your Firebase database.
+
+# Functions
+
+Functions must be simple return expressions with zero or more parameters.
+
+    function myFunction(arg1, arg2) {
+      return arg1 == arg2.value;
+    }
 
 # Expressions
 
 Rule expressions are a subset of JavaScript expressions, and include:
 
   - Unary operators: - (minus), ! (boolean negation)
-  - Binary operators: +, -, *, /, %, instanceof
+  - Binary operators: +, -, *, /, %
+
+References to data locations (starting with `this`, `data`, or `root`) can be further qualified
+using the . and [] operators (just as in JavaScript Object references).
+
+    this.prop  - Refers to property of the current location named 'prop'.
+    this[prop] - Refers to a property of the current location named with the value of the
+                (string) variable, prop.

--- a/docs/language.md
+++ b/docs/language.md
@@ -55,8 +55,7 @@ within an expression as a variable parameter.
       }
     }
 
-In expressions, the value of `this` is defined to be *new* value at the path location (i.e.
-if writing, it is the value at the location after the write would have been complete).
+In expressions, the value of `this` is either the current value to `read()` or the new value to `write()`.
 
 # Types
 

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -191,17 +191,20 @@ util.methods(Symbols, {
     this.register('functions', name, fn);
   },
 
-  registerPath: function(parts, methods) {
+  registerPath: function(parts, isType, methods) {
+    isType = isType || 'Any';
     var p = {
       parts: parts,
+      isType: isType,
       methods: methods
     };
     this.register('paths', '/' + parts.join('/'), p);
   },
 
   registerSchema: function(name, derivedFrom, properties, methods) {
+    derivedFrom = derivedFrom || (Object.keys(properties).length > 0 ? 'Object' : 'Any');
     var s = {
-      derivedFrom: derivedFrom || 'Object',
+      derivedFrom: derivedFrom,
       properties: properties,
       methods: methods
     };

--- a/lib/file-io.js
+++ b/lib/file-io.js
@@ -41,7 +41,7 @@ function readJSONFile(path, fnFallback) {
 }
 
 function writeJSONFile(path, data) {
-  return writeFile(path, JSON.stringify(data, null, 2));
+  return writeFile(path, util.prettyJSON(data));
 }
 
 function readFile(path) {

--- a/lib/firebase-rest.js
+++ b/lib/firebase-rest.js
@@ -72,7 +72,7 @@ util.methods(Client, {
       options.path += '?' + querystring.stringify(query);
     }
 
-    content = JSON.stringify(content, undefined, 2);
+    content = util.prettyJSON(content);
 
     return request(options, content, this.debug)
       .then(function(body) {
@@ -93,7 +93,7 @@ function request(options, content, debug) {
     }
   }
 
-  log("Request: " + JSON.stringify(options, undefined, 2));
+  log("Request: " + util.prettyJSON(options));
   if (content) {
     log("Body: '" + content + "'");
   }

--- a/lib/rules-generator.js
+++ b/lib/rules-generator.js
@@ -27,7 +27,7 @@ module.exports = {
 var errors = {
   badIndex: "Index function must return (an array of) string(s).",
   noPaths: "Must have at least one path expression.",
-  nonObject: "Type contains properties and must extend 'object'.",
+  nonObject: "Type contains properties and must extend 'Object'.",
   missingSchema: "Missing definition for type.",
   recursive: "Recursive function call.",
   mismatchParams: "Incorrect number of function arguments.",
@@ -47,7 +47,6 @@ var JS_OPS = {
   '>': { p: 11 },
   '>=': { p: 11 },
   'in': { p: 11 },
-  'instanceof': { p: 11 },
   '==': { p: 10 },
   "!=": { p: 10 },
   '&&': { p: 6 },
@@ -72,9 +71,7 @@ function Generator(symbols) {
   this.runSilently = false;
 
   this.globals = {
-    // Hack - this in path validation functions is newData.
     "this": ast.snapshotVariable('newData'),
-    "newData": ast.snapshotVariable('newData'),
     "root": ast.snapshotVariable('root'),
     "data": ast.snapshotVariable('data'),
   };
@@ -123,6 +120,8 @@ methods(Generator, {
     this.registerValidator('Boolean', ast.call(ast.reference(thisVar, 'isBoolean'), []));
     // this == null
     this.registerValidator('Null', ast.eq(thisVar, ast.nullType()));
+    // true
+    this.registerValidator('Any', ast.boolean(true));
   },
 
   // Return a validator expression that returns true iff
@@ -137,14 +136,14 @@ methods(Generator, {
 
     var hasProps = Object.keys(schema.properties).length > 0;
 
+    if (hasProps && !this.symbols.isDerivedFrom(schemaName, 'Object')) {
+      throw new Error(errors.nonObject + " (" + schemaName + " is " + schema.derivedFrom + ")");
+    }
+
     // @validator@<T>(this)
     if (schema.derivedFrom != 'Object' || !hasProps) {
       terms.push(ast.call(ast.variable('@validator@' + schema.derivedFrom),
                           [ thisVar ]));
-    }
-
-    if (hasProps && !this.symbols.isDerivedFrom(schemaName, 'Object')) {
-      throw new Error(errors.nonObject + " (" + schemaName + ")");
     }
 
     for (var propName in schema.properties) {
@@ -177,9 +176,17 @@ methods(Generator, {
   // Update rules based on the given path expression.
   updateRules: function(path) {
     var i;
-    var pathMethods = ['read', 'write', 'validate'];
+    var pathMethods = ['read', 'write'];
     var location = this.ensurePath(path.parts);
 
+    // Write validation (if non-trivial)
+    location['.validate'] = this.getExpressionText(
+      this.partialEval(this.symbols.functions['@validator@' + path.isType].body));
+    if (location['.validate'] == 'true') {
+      delete location['.validate'];
+    }
+
+    // Write read and write methods
     for (i = 0; i < pathMethods.length; i++) {
       var method = pathMethods[i];
       if (path.methods[method]) {
@@ -187,6 +194,7 @@ methods(Generator, {
       }
     }
 
+    // Write indices
     if (path.methods.index) {
       var exp = path.methods.index.body;
       if (exp.type == 'String') {
@@ -281,19 +289,6 @@ methods(Generator, {
 
     switch (exp.type) {
     case 'op':
-      if (exp.op == 'instanceof') {
-        var dataType = exp.args[1];
-        if (dataType.type != 'var' || !this.symbols.schema[dataType.name]) {
-          throw new Error(errors.missingType + " (" + dataType.name + ")");
-        }
-        innerParams['this'] = subExpression(exp.args[0]);
-        // TODO: Do as call - to get arg checking on expansion...
-        exp = this.partialEval(this.symbols.functions['@validator@' + dataType.name].body,
-                               innerParams,
-                               functionCalls);
-        break;
-      }
-
       // Ensure arguments are boolean (or values) where needed.
       if (exp.op == '||' || exp.op == '&&') {
         for (i = 0; i < exp.args.length; i++) {

--- a/lib/simulator.js
+++ b/lib/simulator.js
@@ -211,7 +211,7 @@ util.methods(RulesTest, {
       return;
     }
     args = util.copyArray(args).map(function(x) {
-      return JSON.stringify(x, undefined, 2);
+      return util.prettyJSON(x);
     });
     var label = op + '(' + args.join(', ') + ')';
     this.steps.push({label: label, fn: fn});

--- a/lib/util.js
+++ b/lib/util.js
@@ -24,6 +24,7 @@ module.exports = {
   'maybePromise': maybePromise,
   'ensureExtension': ensureExtension,
   'getProp': maybePromise(function(obj, prop) { return obj[prop]; }),
+  'prettyJSON': prettyJSON,
 };
 
 function methods(ctor, obj) {
@@ -108,4 +109,8 @@ function maybePromise(fn) {
 
 function ensureExtension(fileName, extension) {
   return fileName + '.' + extension;
+}
+
+function prettyJSON(o) {
+  return JSON.stringify(o, null, 2);
 }

--- a/test/generator-test.js
+++ b/test/generator-test.js
@@ -18,7 +18,6 @@
 var bolt = (typeof(window) != 'undefined' && window.bolt) || require('bolt');
 var parse = bolt.parse;
 var fileio = require('file-io');
-var util = require('../lib/util');
 
 var assert = require('chai').assert;
 

--- a/test/generator-test.js
+++ b/test/generator-test.js
@@ -17,8 +17,8 @@
 
 var bolt = (typeof(window) != 'undefined' && window.bolt) || require('bolt');
 var parse = bolt.parse;
-var Promise = require('promise');
-var readFile = require('file-io').readFile;
+var fileio = require('file-io');
+var util = require('../lib/util');
 
 var assert = require('chai').assert;
 
@@ -87,31 +87,31 @@ index() { return ['a', 'b']; }\
     assert.deepEqual(json, {rules: {".indexOn": ["a", "b"]}});
   });
 
-  test("Sample files", function() {
+  suite("Sample files", function() {
     var files = [
       "all_access",
       "userdoc",
       "mail"
     ];
-    var completed = [];
     for (var i = 0; i < files.length; i++) {
-      completed.push(testFileSample('test/samples/' + files[i] + '.' + bolt.FILE_EXTENSION));
+      test(files[i],
+           testFileSample.bind(undefined,
+                               'test/samples/' + files[i] +
+                               '.' + bolt.FILE_EXTENSION));
     }
-    return Promise.all(completed);
   });
 
   function testFileSample(filename) {
-    return readFile(filename)
+    return fileio.readFile(filename)
       .then(function(response) {
         var result = parse(response.content);
         assert.ok(result, response.url);
         var gen = new bolt.Generator(result);
         var json = gen.generateRules();
         assert.ok('rules' in json, response.url + " has rules");
-        return readFile(response.url.replace('.' + bolt.FILE_EXTENSION, '.json'))
+        return fileio.readJSONFile(response.url.replace('.' + bolt.FILE_EXTENSION, '.json'))
           .then(function(response2) {
-            assert.deepEqual(json, JSON.parse(response2.content),
-                             "Generated JSON should match " + response2.url);
+            assert.deepEqual(json, response2);
           });
       })
       .catch(function(error) {
@@ -160,7 +160,6 @@ index() { return ['a', 'b']; }\
       [ "a > 7" ],
       [ "a <= 7" ],
       [ "a >= 7" ],
-      [ "a instanceof Document" ],
       [ "a == 3" ],
       [ "a != 0" ],
       [ "a === 3", "a == 3" ],
@@ -254,31 +253,32 @@ path /x { read() { return " + tests[i].x + "; }}\
 
   test("Schema Validation", function() {
     var tests = [
-      { s: "type Simple {}", v: "this instanceof Simple",
+      { s: "type Simple extends Object {}",
         x: "newData.hasChildren()" },
-      { s: "type Simple extends String {}", v: "this instanceof Simple", x: "newData.isString()" },
-      { s: "type Simple {n: Number}", v: "this instanceof Simple",
+      { s: "type Simple extends String {}",
+        x: "newData.isString()" },
+      { s: "type Simple {n: Number}",
         x: "newData.child('n').isNumber()" },
-      { s: "type Simple {s: String}", v: "this instanceof Simple",
+      { s: "type Simple {s: String}",
         x: "newData.child('s').isString()" },
-      { s: "type Simple {b: Boolean}", v: "this instanceof Simple",
+      { s: "type Simple {b: Boolean}",
         x: "newData.child('b').isBoolean()" },
-      { s: "type Simple {x: Object}", v: "this instanceof Simple",
+      { s: "type Simple {x: Object}",
         x: "newData.child('x').hasChildren()" },
-      { s: "type Simple {x: Number|String}", v: "this instanceof Simple",
+      { s: "type Simple {x: Number|String}",
         x: "newData.child('x').isNumber() || newData.child('x').isString()" },
-      { s: "type Simple {a: Number, b: String}", v: "this instanceof Simple",
+      { s: "type Simple {a: Number, b: String}",
         x: "newData.child('a').isNumber() && newData.child('b').isString()" },
-      { s: "type Simple {x: Number|Null}", v: "this instanceof Simple",
+      { s: "type Simple {x: Number|Null}",
         x: "newData.child('x').isNumber() || newData.child('x').val() == null" },
-      { s: "type Simple {n: Number, validate() {return this.n < 7;}}", v: "this instanceof Simple",
+      { s: "type Simple {n: Number, validate() {return this.n < 7;}}",
         x: "newData.child('n').isNumber() && newData.child('n').val() < 7" },
     ];
     for (var i = 0; i < tests.length; i++) {
-      var symbols = parse(tests[i].s + " path /x { validate() { return " + tests[i].v + "; }}");
+      var symbols = parse(tests[i].s + " path /x is Simple {}");
       var gen = new bolt.Generator(symbols);
-      var decode = gen.getExpressionText(symbols.paths['/x'].methods.validate.body);
-      assert.equal(decode, tests[i].x, tests[i].x);
+      var rules = gen.generateRules();
+      assert.deepEqual(rules, {"rules": {"x": {".validate": tests[i].x}}});
     }
   });
 
@@ -290,7 +290,7 @@ path /x { read() { return " + tests[i].x + "; }}\
         e: /properties.*extend/ },
       { s: "path /y { index() { return 1; }}",
         e: /index.*string/i },
-      { s: "path /x { validate() { return undefinedFunc(); }}",
+      { s: "path /x { write() { return undefinedFunc(); }}",
         e: "1 errors" },
     ];
 

--- a/test/parser-test.js
+++ b/test/parser-test.js
@@ -38,9 +38,10 @@ function fnAST() {
   };
 }
 
-var path = "path /p {}";
+var path = "path /x {}";
 var pathAST = {
-  parts: ['p'],
+  parts: ['x'],
+  isType: 'Any',
   methods: {}
 };
 
@@ -132,7 +133,6 @@ suite("Rules Parser Tests", function() {
       [ "a > 7", ast.gt(ast.variable('a'), ast.number(7)) ],
       [ "a <= 7", ast.lte(ast.variable('a'), ast.number(7)) ],
       [ "a >= 7", ast.gte(ast.variable('a'), ast.number(7)) ],
-      [ "a instanceof Document", ast.instanceOf(ast.variable('a'), ast.variable('Document')) ],
       [ "a == 3", ast.eq(ast.variable('a'), ast.number(3)) ],
       [ "a != 0", ast.ne(ast.variable('a'), ast.number(0)) ],
       [ "a === 3", ast.eq(ast.variable('a'), ast.number(3)) ],
@@ -199,13 +199,14 @@ suite("Rules Parser Tests", function() {
 
   test("Path", function() {
     var result = parse(path);
-    assert.deepEqual(result.paths, {'/p': pathAST});
+    assert.deepEqual(result.paths, {'/x': pathAST});
   });
 
   test("Root Path", function() {
     var result = parse("path / {}");
     assert.deepEqual(result.paths['/'], {
       parts: [],
+      isType: 'Any',
       methods: {}
     });
   });
@@ -270,14 +271,15 @@ return true;\
     var result = parse("\
 path /p/$q {\
 \
-validate() {\
+write() {\
 return true;\
 }\
 }");
     assert.deepEqual(result.paths['/p/$q'], {
       parts: ['p', '$q'],
+      isType: 'Any',
       methods: {
-        validate: {
+        write: {
           params: [],
           body: {
             type: "Boolean",

--- a/test/samples/mail.bolt
+++ b/test/samples/mail.bolt
@@ -14,9 +14,7 @@ type Message {
 }
 
 // The inbox is someone's incoming mail.
-path /users/$userid/inbox/$msg {
-  validate() { return this instanceof Message; }
-
+path /users/$userid/inbox/$msg is Message {
   // Users can read their own inbox
   read() { return isCurrentUser($userid); }
 
@@ -30,9 +28,7 @@ path /users/$userid/inbox/$msg {
 }
 
 // The outbox is for recording what has been sent by a user.
-path /users/$userid/outbox/$msg {
-  validate() { return this instanceof Message; }
-
+path /users/$userid/outbox/$msg is Message {
   read() { return isCurrentUser($userid); }
 
   write() {

--- a/test/samples/userdoc.bolt
+++ b/test/samples/userdoc.bolt
@@ -21,45 +21,45 @@ type Metadata {
 }
 
 type Permission {
-  grantor: Userid,
+  owner: Userid,
   grantee: Userid,
   docid: Docid
 }
 
-// Note no query support for /documents/$userid.
-path /documents/$userid/$docid {
-  validate() { return this instanceof Document; }
-  read() { return isCurrentUser($userid) || hasPermission($docid, 'read'); }
-  write() { return isCurrentUser($userid) || hasPermission($docid, 'write'); }
+path /documents/$ownerid {
+  read()  { return isCurrentUser($ownerid); }
+  write() { return isCurrentUser($ownerid); }
+}
+
+path /documents/$ownerid/$docid is Document {
+  read()  { return hasPermission($ownerid, $docid, 'read'); }
+  write() { return hasPermission($ownerid, $docid, 'write'); }
 }
 
 // Allow reading the list of all a user's own metadata.
-path /metadata/$userid {
-  read() { return isCurrentUser($userid); }
+path /metadata/$ownerid {
+  read()  { return isCurrentUser($ownerid); }
+  write() { return isCurrentUser($ownerid); }
 }
 
-path /metadata/$userid/$docid {
-  validate() { return this instanceof Metadata; }
-  read() { return hasPermission($docid, 'read'); }
-  write() { return isCurrentUser($userid) || hasPermission($docid, 'write'); }
+path /metadata/$ownerid/$docid is Metadata {
+  read()  { return hasPermission($ownerid, $docid, 'read'); }
+  write() { return hasPermission($ownerid, $docid, 'write'); }
 }
 
 path /permissions {
-  read() { return isLoggedIn(); }
-  index() { return ['grantor', 'grantee', 'docid']; }
+  read()  { return isLoggedIn(); }
+  index() { return ['owner', 'grantee', 'docid']; }
 }
 
-path /permissions/$key {
-  // Limit structure of the key format to "grantee|docid".
-  validate() {
-    return this instanceof Permission &&
-           $key == fullId(this.grantee, this.docid) &&
-           this.grantor == currentUser();
-  }
+path /permissions/$key is Permission {
   write() {
-    // BUG: Can have two-docid's owned by different owners - permissions can be stolen!
-    return this == null && isCurrentUser(data.grantor) ||
-           this != null && docIsOwnedBy(this.docid, currentUser());
+    return this == null && isCurrentUser(data.owner) ||
+      this != null &&
+      // Limit structure of the key format to "grantee|owner|docid"
+      $key == fullId(this.grantee, this.owner, this.docid) &&
+      isCurrentUser(this.owner) &&
+      docIsOwnedBy(this.docid, currentUser());
   }
   // No read() rule neeeded since this is only used in hasPermission()
 }
@@ -76,12 +76,12 @@ function currentUser() {
   return auth.uid;
 }
 
-function fullId(userid, docid) {
-  return userid + '|' + docid;
+function fullId(userid, ownerid, docid) {
+  return userid + '|' + ownerid + '|' + docid;
 }
 
-function hasPermission(docid, p) {
-  return root.permissions[fullId(currentUser(), docid)][p];
+function hasPermission(ownerid, docid, p) {
+  return root.permissions[fullId(currentUser(), ownerid, docid)][p];
 }
 
 function docIsOwnedBy(docid, userid) {

--- a/test/samples/userdoc.json
+++ b/test/samples/userdoc.json
@@ -1,34 +1,37 @@
 {
   "rules": {
     "documents": {
-      "$userid": {
+      "$ownerid": {
+        ".read": "auth.uid == $ownerid",
+        ".write": "auth.uid == $ownerid",
         "$docid": {
-          ".read": "auth.uid == $userid || root.child('permissions').child(auth.uid + '|' + $docid).child('read').val() == true",
-          ".write": "auth.uid == $userid || root.child('permissions').child(auth.uid + '|' + $docid).child('write').val() == true",
-          ".validate": "newData.hasChildren()"
+          ".validate": "newData.hasChildren()",
+          ".read": "root.child('permissions').child(auth.uid + '|' + $ownerid + '|' + $docid).child('read').val() == true",
+          ".write": "root.child('permissions').child(auth.uid + '|' + $ownerid + '|' + $docid).child('write').val() == true"
         }
       }
     },
     "metadata": {
-      "$userid": {
-        ".read": "auth.uid == $userid",
+      "$ownerid": {
+        ".read": "auth.uid == $ownerid",
+        ".write": "auth.uid == $ownerid",
         "$docid": {
-          ".read": "root.child('permissions').child(auth.uid + '|' + $docid).child('read').val() == true",
-          ".write": "auth.uid == $userid || root.child('permissions').child(auth.uid + '|' + $docid).child('write').val() == true",
-          ".validate": "newData.child('created').isString() && newData.child('modified').isString() && newData.child('title').isString()"
+          ".validate": "newData.child('created').isString() && newData.child('modified').isString() && newData.child('title').isString()",
+          ".read": "root.child('permissions').child(auth.uid + '|' + $ownerid + '|' + $docid).child('read').val() == true",
+          ".write": "root.child('permissions').child(auth.uid + '|' + $ownerid + '|' + $docid).child('write').val() == true"
         }
       }
     },
     "permissions": {
       ".read": "auth != null",
       ".indexOn": [
-        "grantor",
+        "owner",
         "grantee",
         "docid"
       ],
       "$key": {
-        ".write": "newData.val() == null && auth.uid == data.child('grantor').val() || newData.val() != null && root.child('documents').child(auth.uid).child(newData.child('docid').val()).val() != null",
-        ".validate": "newData.child('grantor').isString() && newData.child('grantee').isString() && newData.child('docid').isString() && $key == newData.child('grantee').val() + '|' + newData.child('docid').val() && newData.child('grantor').val() == auth.uid"
+        ".validate": "newData.child('owner').isString() && newData.child('grantee').isString() && newData.child('docid').isString()",
+        ".write": "newData.val() == null && auth.uid == data.child('owner').val() || newData.val() != null && $key == newData.child('grantee').val() + '|' + newData.child('owner').val() + '|' + newData.child('docid').val() && auth.uid == newData.child('owner').val() && root.child('documents').child(auth.uid).child(newData.child('docid').val()).val() != null"
       }
     }
   }

--- a/tools/compare-sample
+++ b/tools/compare-sample
@@ -4,4 +4,4 @@
 set -e
 
 cd $PROJ_DIR/test/samples
-firebase-bolt < $1.bolt | diff - $1.json
+diff <(firebase-bolt < $1.bolt | flatten-json.py) <(flatten-json.py < $1.json)

--- a/tools/flatten-json.py
+++ b/tools/flatten-json.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+#
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import sys
+import json
+
+
+def main():
+  data = json.load(sys.stdin)
+  lines = []
+  extract_values(data, '', lines)
+  lines.sort()
+  print('\n'.join(lines))
+
+
+def extract_values(j, base, lines):
+  if type(j) is dict:
+    for p in j:
+      extract_values(j[p], base + '/' + p, lines)
+    return
+
+  if type(j) is list:
+    for i in range(len(j)):
+      extract_values(j[i], base + '/' + str(i), lines)
+    return
+
+  lines.append(base + ': ' + str(j))
+
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
Toward simplification of rules:

- Removed the instanceof operator.
- Added path /x is Type {...}

Coming to future PR:

- Enforce only type statements have validate() rules.
- Enforce only path statements have read/write rules (and access to auth variable).
- Factor validation into individual property validations of child properties (instead of one big parent expression).

@TristonianJones 
