### PR TITLE
Remove data and replace with prior(this).

### DIFF
--- a/docs/language.md
+++ b/docs/language.md
@@ -116,7 +116,6 @@ in the database):
 
 You can also use:
 
-    data - The value at a location BEFORE a write is done.
     root - The root of your Firebase database.
 
 # Functions
@@ -134,12 +133,21 @@ Rule expressions are a subset of JavaScript expressions, and include:
   - Unary operators: - (minus), ! (boolean negation)
   - Binary operators: +, -, *, /, %
 
-References to data locations (starting with `this`, `data`, or `root`) can be further qualified
+References to data locations (starting with `this` or `root`) can be further qualified
 using the . and [] operators (just as in JavaScript Object references).
 
     this.prop  - Refers to property of the current location named 'prop'.
     this[prop] - Refers to a property of the current location named with the value of the
                 (string) variable, prop.
+
+To reference the previous value of a property (in a write() or validate() rule), wrap
+the reference in a `prior()` function:
+
+    prior(this) - Value of `this` before the write is completed.
+    prior(this.prop) - Value of a property before the write is completed.
+
+You can also use `prior()` to wrap any expressions (including function calls) that
+use `this`.
 
 # Apendix A. Firebase Expressions and their Bolt equivalents.
 
@@ -162,8 +170,8 @@ API | Bolt Equivalent
 auth | auth
 $location | $location (in path statement)
 now | NYI
-data | data
-newData | this
+data | prior(this)
+newData | this (in validate() and write() rules)
 
 ## RuleDataSnapshot Methods
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -2,13 +2,13 @@
 
 # Language changes
 
-- Support for match function (and register all current FB server functions and
+X Support for match function (and register all current FB server functions and
   methods).
 - Errors: esp undefined functions and variable references.
 - Nested path and functions (scoped).
-- Use Javascript names for types (String, Boolean, Number, Object).
+X Use Javascript names for types (String, Boolean, Number, Object).
 - Add command line handling for firebase-bolt.
-- How to mudularly include an external rule set.
+- How to mudularly include an external rule set (import rules [as alias] [at /path])
 - Generate (Java) language stubs based on schema (cf bolt_compiler experiment).
 - Handle extensible.
   - Use hasChildren in .validate along with sibling .validate rules for each
@@ -28,7 +28,7 @@ X Switch to Mocha/Chai
   X Import firebase realtime lib (not needed?)
     - Add promise-based get/set to lib/firebase-promises
   - Save each test under /bolt-simulator/$filename/$date
-  - asAdmin - for db setup.
+  x asAdmin - for db setup.
   X asynch execution of test.
   X Setup auth-secrets from prompts (CLI)
 - Concept of "coverage" for behavioral tests?  (Like ensure every property that
@@ -41,7 +41,9 @@ X Switch to Mocha/Chai
   not throwing exceptions as the source seems to implied.  Can't figure out how
   to run non-minified version.
   username, provider would be nice to set for simulator....
+  (improper use of token generator - options vs properties).
 - The admin: true option does not seem to work in the tokenGenerator.
+  (improper use of token generator - options vs properties).
 
 # Repo structure and OSS
 
@@ -49,7 +51,7 @@ X Apache license.
 X Contributing
 X check-oss-release script
 X Add license to all source files.
-- Add GoogleBot for CLA checks (Rob help)
+X Add GoogleBot for CLA checks (Rob help)
 X Remove namespace.js.
 - Cleanup browserify rules - ugly (prefer glob-ing test files and running as a merged stream).
 - Setup catapult (Jacob help)

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -97,6 +97,12 @@ function reference(base, prop) {
   };
 }
 
+// Make a (shallow) copy of the base expression, setting (or removing) it's
+// valueType.
+//
+// valueType is a string indicating the type of evaluating an expression (e.g.
+// 'Snapshot') - used to know when type coercion is needed in the context
+// of parent expressions.
 function cast(base, valueType) {
   var result = util.extend({}, base);
   if (valueType) {

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -21,18 +21,22 @@ var util = require('./util');
 
 var string = valueGen('String');
 var eq = opGen('==');
-var nop = opGen('nop', 1);
 var boolean = valueGen('Boolean');
 
 module.exports = {
   'variable': variable,
+  'literal': literal,
   'nullType': nullType,
   'reference': reference,
   'call': call,
+  'builtin': builtin,
+
+  // TODO: Moves these out of ast.js
   'snapshotVariable': snapshotVariable,
   'snapshotChild': snapshotChild,
   'snapshotParent': snapshotParent,
   'snapshotValue': snapshotValue,
+
   'cast': cast,
   'ensureValue': ensureValue,
   'ensureBoolean': ensureBoolean,
@@ -59,7 +63,6 @@ module.exports = {
   'and': opGen('&&'),
   'or': opGen('||'),
   'ternary': opGen('?:', 3),
-  'nop': nop,
   'value': opGen('value', 1),
 
   'andArray': leftAssociateGen('&&', boolean(true)),
@@ -78,6 +81,10 @@ function variable(name) {
   return { type: 'var', name: name };
 }
 
+function literal(name) {
+  return { type: 'literal', name: name };
+}
+
 function nullType() {
   return { type: 'Null' };
 }
@@ -91,9 +98,11 @@ function reference(base, prop) {
 }
 
 function cast(base, valueType) {
-  var result = nop(base);
+  var result = util.extend({}, base);
   if (valueType) {
     result.valueType = valueType;
+  } else {
+    delete result.valueType;
   }
   return result;
 }
@@ -101,6 +110,10 @@ function cast(base, valueType) {
 function call(ref, args) {
   args = args || [];
   return { type: 'call', ref: ref, args: args };
+}
+
+function builtin(fn) {
+  return { type: 'builtin', fn: fn };
 }
 
 function snapshotVariable(name) {
@@ -114,7 +127,8 @@ function snapshotChild(base, accessor) {
   if (base.valueType != 'Snapshot') {
     throw new Error(errors.typeMismatch + "expected Snapshot");
   }
-  return cast(call(reference(cast(base), 'child'), [accessor]), 'Snapshot');
+  var result = cast(call(reference(base, 'child'), [accessor]), 'Snapshot');
+  return result;
 }
 
 function snapshotParent(base) {
@@ -196,6 +210,7 @@ function array(args) {
   return { type: 'Array', value: args };
 }
 
+// Warning: NOT an expression type!
 function method(params, body) {
   return {
     params: params,
@@ -227,11 +242,7 @@ util.methods(Symbols, {
   },
 
   registerFunction: function(name, params, body) {
-    var fn = {
-      params: params,
-      body: body
-    };
-    this.register('functions', name, fn);
+    this.register('functions', name, method(params, body));
   },
 
   registerPath: function(parts, isType, methods) {

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -45,7 +45,8 @@ module.exports = {
   'number': valueGen('Number'),
   'boolean': boolean,
   'string': string,
-  'array': array,
+  'array': valueGen('Array'),
+  'regexp': valueGen('RegExp'),
 
   'neg': opGen('neg', 1),
   'not': opGen('!', 1),
@@ -78,20 +79,21 @@ var errors = {
 };
 
 function variable(name) {
-  return { type: 'var', name: name };
+  return { type: 'var', valueType: 'Any', name: name };
 }
 
 function literal(name) {
-  return { type: 'literal', name: name };
+  return { type: 'literal', valueType: 'Any', name: name };
 }
 
 function nullType() {
-  return { type: 'Null' };
+  return { type: 'Null', valueType: 'Null' };
 }
 
 function reference(base, prop) {
   return {
     type: 'ref',
+    valueType: 'Any',
     base: base,
     accessor: prop
   };
@@ -105,21 +107,17 @@ function reference(base, prop) {
 // of parent expressions.
 function cast(base, valueType) {
   var result = util.extend({}, base);
-  if (valueType) {
-    result.valueType = valueType;
-  } else {
-    delete result.valueType;
-  }
+  result.valueType = valueType;
   return result;
 }
 
 function call(ref, args) {
   args = args || [];
-  return { type: 'call', ref: ref, args: args };
+  return { type: 'call', valueType: 'Any', ref: ref, args: args };
 }
 
 function builtin(fn) {
-  return { type: 'builtin', fn: fn };
+  return { type: 'builtin', valueType: 'Any', fn: fn };
 }
 
 function snapshotVariable(name) {
@@ -168,12 +166,18 @@ function isCall(exp, methodName) {
   return exp.type == 'call' && exp.ref.type == 'ref' && exp.ref.accessor == methodName;
 }
 
+// Return value generating function for a given Type.
 function valueGen(type) {
   return function(value) {
-    return { type: type, value: value };
+    return {
+      type: type,         // Exp type identifying a constant value of this Type.
+      valueType: type,    // The type of the result of evaluating this expression.
+      value: value        // The (constant) value itself.
+    };
   };
 }
 
+// Return a generating function to make an operator exp node.
 function opGen(opType, arity) {
   if (arity === undefined) {
     arity = 2;
@@ -209,11 +213,12 @@ function leftAssociateGen(opType, initialValue) {
 }
 
 function op(opType, args) {
-  return { type: 'op', op: opType, args: args };
-}
-
-function array(args) {
-  return { type: 'Array', value: args };
+  return {
+    type: 'op',     // This is (multi-argument) operator.
+    valueType: 'Any',
+    op: opType,     // The operator (string, e.g. '+').
+    args: args      // Arguments to the operator Array<exp>
+  };
 }
 
 // Warning: NOT an expression type!

--- a/lib/rules-generator.js
+++ b/lib/rules-generator.js
@@ -35,12 +35,12 @@ var errors = {
   badSchemaMethod: "Unsupported method name in type statement: ",
   badPathMethod: "Unsupported method name in path statement: ",
   coercion: "Cannot convert value: ",
+  undefinedFunction: "Undefined function: ",
 };
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence
 var JS_OPS = {
   'value': { rep: "", p: 16 },
-  'nop': { rep: "", p: 16 },
 
   'neg': { rep: "-", p: 15},
   '!': { p: 15},
@@ -64,10 +64,12 @@ var JS_OPS = {
 
 var builtinSchemaNames = ['Any', 'Null', 'String', 'Number', 'Boolean', 'Object'];
 // Method names allowed in Bolt files.
-var valueMethods = ['length', 'includes', 'startsWith', 'endsWith',
-                    'replace', 'toLowerCase', 'toUpperCase', 'test'];
-var snapshotMethods = ['parent'];
-var reservedMethods = snapshotMethods.concat(valueMethods);
+var valueMethods = ['length', 'includes', 'startsWith', 'beginsWith', 'endsWith',
+                    'replace', 'toLowerCase', 'toUpperCase', 'test', 'contains',
+                    'matches'];
+// TODO: Make sure users don't call internal methods...make private to impl.
+var snapshotMethods = ['parent', 'child', 'hasChildren', 'val', 'isString', 'isNumber',
+                       'isBoolean'].concat(valueMethods);
 
 // Symbols contains:
 //   functions: {}
@@ -79,12 +81,13 @@ function Generator(symbols) {
   this.rules = {};
   this.errorCount = 0;
   this.runSilently = false;
+  this.allowUndefinedFunctions = false;
 
+  // TODO: globals should be part of this.symbols.
   this.globals = {
-    "this": ast.snapshotVariable('newData'),
-    "root": ast.snapshotVariable('root'),
-    "data": ast.snapshotVariable('data'),
+    "root": ast.cast(ast.literal('root'), 'Snapshot'),
   };
+  this.globalStacks = {};
 
   this.registerBuiltinSchema();
 }
@@ -147,9 +150,9 @@ util.methods(Generator, {
     var self = this;
     var thisVar = ast.variable('this');
 
-    function registerAsCall(name, fnCall) {
+    function registerAsCall(name, methodName) {
       self.symbols.registerSchema(name, 'Any', undefined, {
-        validate: ast.method(['this'], ast.call(ast.reference(ast.cast(thisVar), fnCall)))
+        validate: ast.method(['this'], ast.call(ast.reference(ast.cast(thisVar), methodName)))
       });
     }
 
@@ -162,29 +165,23 @@ util.methods(Generator, {
     });
 
     self.symbols.registerSchema('String', 'Any', undefined, {
-      validate: ast.method(['this'], ast.call(ast.reference(ast.cast(thisVar), 'isString'))),
-      includes: ast.method(['this', 's'], ast.call(ast.reference(ast.value(thisVar), 'contains'),
-                                                   [ ast.value(ast.variable('s')) ])),
+      validate: ast.method(['this'],
+                           ast.call(ast.reference(ast.cast(thisVar), 'isString'))),
+      includes: ast.method(['this', 's'],
+                           ast.call(ast.reference(ast.value(thisVar), 'contains'),
+                                    [ ast.value(ast.variable('s')) ])),
       startsWith: ast.method(['this', 's'],
                              ast.call(ast.reference(ast.value(thisVar), 'beginsWith'),
                                       [ ast.value(ast.variable('s')) ])),
-      endsWith: ast.method(['this', 's'], ast.call(ast.reference(ast.value(thisVar), 'endsWith'),
-                                                     [ ast.value(ast.variable('s')) ])),
+      endsWith: ast.method(['this', 's'],
+                           ast.call(ast.reference(ast.value(thisVar), 'endsWith'),
+                                    [ ast.value(ast.variable('s')) ])),
       replace: ast.method(['this', 's', 'r'],
                           ast.call(ast.reference(ast.value(thisVar), 'replace'),
                                    [ ast.value(ast.variable('s')), ast.value(ast.variable('r')) ])),
-      test: ast.method(['this', 's'], ast.call(ast.reference(ast.value(thisVar), 'matches'),
-                                               [ ast.cast(ast.variable('s'), 'RegExp') ])),
-      /*
-      length:
-      beginsWith
-      endsWith
-      replace
-      toLowerCase
-      toUpperCase
-      matches: { enabled: false, on: 'String', args: ['RegExp'], returns: 'Boolean'},
-      */
-
+      test: ast.method(['this', 's'],
+                       ast.call(ast.reference(ast.value(thisVar), 'matches'),
+                                [ ast.cast(ast.variable('s'), 'RegExp') ])),
     });
 
     registerAsCall('Object', 'hasChildren');
@@ -249,7 +246,8 @@ util.methods(Generator, {
   // Update rules based on the given path expression.
   updateRules: function(path) {
     var i;
-    var pathMethods = ['read', 'write'];
+    var pathMethods = [{ method: 'read', thisIs: 'data'},
+                       { method: 'write', thisIs: 'newData' }];
     var location = this.ensurePath(path.parts);
     var exp;
 
@@ -259,19 +257,19 @@ util.methods(Generator, {
       terms.push(path.methods.validate.body);
     }
     terms.push(this.symbols.functions['@validator@' + path.isType].body);
+    exp = ast.andArray(terms);
 
-    exp = this.partialEval(ast.andArray(terms));
     if (!(exp.type == 'Boolean' && exp.value == true)) {
-      location['.validate'] = this.getExpressionText(exp);
+      location['.validate'] = this.getExpressionText(exp, 'newData');
     }
 
     // Write read and write methods
     for (i = 0; i < pathMethods.length; i++) {
-      var method = pathMethods[i];
+      var method = pathMethods[i].method;
       if (path.methods[method]) {
         exp = path.methods[method].body;
         if (!(exp.type == 'Boolean' && exp.value == false)) {
-          location['.' + method] = this.getExpressionText(exp);
+          location['.' + method] = this.getExpressionText(exp, pathMethods[i].thisIs);
         }
       }
     }
@@ -298,8 +296,24 @@ util.methods(Generator, {
     }
   },
 
-  getExpressionText: function(exp) {
+  getExpressionText: function(exp, thisIs) {
+    // First evaluate w/o binding of this to specific location.
+    this.allowUndefinedFunctions = true;
+    exp = this.partialEval(exp, { 'this': ast.cast(ast.call(ast.variable('@getThis')),
+                                                   'Snapshot') });
+    // Now re-evaluate the flattened expression.
+    this.allowUndefinedFunctions = false;
+    this.thisIs = thisIs || 'newData';
+    this.symbols.registerFunction('@getThis', [],
+                                  ast.builtin(this.getThis.bind(this)));
+    this.symbols.registerFunction('prior', ['exp'],
+                                  ast.builtin(this.prior.bind(this)));
+
     exp = this.partialEval(exp);
+
+    delete this.symbols.functions['@getThis'];
+    delete this.symbols.functions.prior;
+
     // Top level expressions should never be to a snapshot reference - should
     // always evaluate to a boolean.
     exp = ast.ensureBoolean(exp);
@@ -368,15 +382,14 @@ util.methods(Generator, {
     }
 
     function lookupVar(exp2) {
+      // TODO: Unbound variable access should be an error.
       return params[exp2.name] || self.globals[exp2.name] || exp2;
     }
 
     switch (exp.type) {
     case 'op':
       // Ensure arguments are boolean (or values) where needed.
-      if (exp.op == 'nop') {
-        args[0] = subExpression(exp.args[0]);
-      } else if (exp.op == 'value') {
+      if (exp.op == 'value') {
         args[0] = valueExpression(subExpression(exp.args[0]));
       } else if (exp.op == '||' || exp.op == '&&' || exp.op == '!') {
         for (i = 0; i < exp.args.length; i++) {
@@ -397,7 +410,18 @@ util.methods(Generator, {
       break;
 
     case 'var':
+      var valueType = exp.valueType;
       exp = lookupVar(exp);
+      if (valueType) {
+        exp.valueType = valueType;
+      }
+      if (valueType == 'RegExp' && (exp.type != 'String' ||
+                                    !/\/.*\//.test(exp.value))) {
+        throw new Error(errors.coercion + decodeExpression(exp) + " => RegExp");
+      }
+      break;
+
+    case 'literal':
       break;
 
     case 'ref':
@@ -415,7 +439,7 @@ util.methods(Generator, {
       if (base.valueType == 'Snapshot') {
         if (accessor == 'parent') {
           return ast.snapshotParent(base);
-        } else if (!util.arrayIncludes(reservedMethods, accessor)) {
+        } else if (!util.arrayIncludes(snapshotMethods, accessor)) {
           return ast.snapshotChild(base, accessor);
         }
       }
@@ -448,21 +472,33 @@ util.methods(Generator, {
                      " but actually passed " + callArgs.length + ")");
           break;
         }
+
+        if (fn.body.type == 'builtin') {
+          return fn.body.fn(callArgs, params);
+        }
+
+        functionCalls[ref.name] = true;
         for (i = 0; i < fn.params.length; i++) {
           innerParams[fn.params[i]] = subExpression(callArgs[i]);
         }
-        functionCalls[ref.name] = true;
         exp = this.partialEval(fn.body, innerParams, functionCalls);
         functionCalls[ref.name] = false;
       } else {
         // Not a global function - expand args.
-        // TODO: Check snapshot and string-specific methods arguments here.
+        if (!this.allowUndefinedFunctions) {
+          var funcName = ref.type == 'ref' ? ref.accessor : ref.name;
+          if (!(funcName in this.symbols.schema.String.methods ||
+                util.arrayIncludes(snapshotMethods, funcName))) {
+            this.fatal(errors.undefinedFunction + decodeExpression(ref));
+          }
+        }
         for (i = 0; i < exp.args.length; i++) {
           args[i] = subExpression(exp.args[i]);
         }
         if (replaceExp()) {
           exp.ref = ref;
           exp.args = args;
+          // TODO: Get rid of this hack (for data.parent().val())
           if (exp.ref.valueType == 'Snapshot') {
             exp.valueType = 'Snapshot';
           }
@@ -474,13 +510,27 @@ util.methods(Generator, {
     return exp;
   },
 
+  // Builtin function
+  prior: function(args, params) {
+    var lastThisIs = this.thisIs;
+    this.thisIs = 'data';
+    var exp = this.partialEval(args[0], params);
+    this.thisIs = lastThisIs;
+    return exp;
+  },
+
+  getThis: function(args, params) {
+    var result = ast.snapshotVariable(this.thisIs);
+    return result;
+  },
+
   // Lookup globally defined function.
   lookupFunction: function(ref) {
     // Global function.
     if (ref.type == 'var') {
       var fn = this.symbols.functions[ref.name];
       if (!fn) {
-        this.fatal("Undefined global function: " + ref.name);
+        return undefined;
       }
       return { self: undefined, fn: fn};
     }
@@ -493,6 +543,19 @@ util.methods(Generator, {
       }
     }
     return undefined;
+  },
+
+  pushGlobal: function(name, exp) {
+    if (!this.globalStacks[name]) {
+      this.globalStacks[name] = [];
+    }
+    var stack = this.globalStacks[name];
+    stack.push(this.globals[name]);
+    this.globals[name] = exp;
+  },
+
+  popGlobal: function(name) {
+    this.globals[name] = this.globalStacks[name].pop();
   },
 
   setLoggers: function(loggers) {
@@ -521,7 +584,11 @@ function decodeExpression(exp, outerPrecedence) {
     break;
 
   case 'String':
-    result = util.quoteString(exp.value);
+    if (exp.valueType == 'RegExp') {
+      result = exp.value;
+    } else {
+      result = util.quoteString(exp.value);
+    }
     break;
 
   case 'Null':
@@ -529,6 +596,7 @@ function decodeExpression(exp, outerPrecedence) {
     break;
 
   case 'var':
+  case 'literal':
     result = exp.name;
     break;
 
@@ -545,17 +613,14 @@ function decodeExpression(exp, outerPrecedence) {
     result = decodeExpression(exp.ref) + '(' + decodeArray(exp.args) + ')';
     break;
 
+  case 'builtin':
+    result = decodeExpression(exp);
+    break;
+
   case 'op':
     var rep = JS_OPS[exp.op].rep === undefined ? exp.op : JS_OPS[exp.op].rep;
     if (exp.args.length == 1) {
-      if (exp.valueType == 'RegExp') {
-        if (exp.args[0].type != 'String' || exp.args[0].value[0] != '/') {
-          throw new Error(errors.coercion + decodeExpression(exp.args[0]) + " => RegExp");
-        }
-        result = exp.args[0].value;
-      } else {
-        result = rep + decodeExpression(exp.args[0], innerPrecedence);
-      }
+      result = rep + decodeExpression(exp.args[0], innerPrecedence);
     } else if (exp.args.length == 2) {
       result =
         decodeExpression(exp.args[0], innerPrecedence) +

--- a/lib/rules-generator.js
+++ b/lib/rules-generator.js
@@ -154,7 +154,8 @@ util.methods(Generator, {
 
     function registerAsCall(name, methodName) {
       self.symbols.registerSchema(name, 'Any', undefined, {
-        validate: ast.method(['this'], ast.call(ast.reference(ast.cast(thisVar), methodName)))
+        validate: ast.method(['this'], ast.call(ast.reference(ast.cast(thisVar, 'Any'),
+                                                              methodName)))
       });
     }
 
@@ -168,7 +169,7 @@ util.methods(Generator, {
 
     self.symbols.registerSchema('String', 'Any', undefined, {
       validate: ast.method(['this'],
-                           ast.call(ast.reference(ast.cast(thisVar), 'isString'))),
+                           ast.call(ast.reference(ast.cast(thisVar, 'Any'), 'isString'))),
       includes: ast.method(['this', 's'],
                            ast.call(ast.reference(ast.value(thisVar), 'contains'),
                                     [ ast.value(ast.variable('s')) ])),
@@ -183,7 +184,7 @@ util.methods(Generator, {
                                    [ ast.value(ast.variable('s')), ast.value(ast.variable('r')) ])),
       test: ast.method(['this', 's'],
                        ast.call(ast.reference(ast.value(thisVar), 'matches'),
-                                [ ast.cast(ast.variable('s'), 'RegExp') ])),
+                                [ ast.call(ast.variable('@RegExp'), [ast.variable('s')]) ])),
     });
 
     registerAsCall('Object', 'hasChildren');
@@ -309,12 +310,15 @@ util.methods(Generator, {
     this.thisIs = thisIs || 'newData';
     this.symbols.registerFunction('@getThis', [],
                                   ast.builtin(this.getThis.bind(this)));
+    this.symbols.registerFunction('@RegExp', ['s'],
+                                  ast.builtin(this.makeRegExp.bind(this)));
     this.symbols.registerFunction('prior', ['exp'],
                                   ast.builtin(this.prior.bind(this)));
 
     exp = this.partialEval(exp);
 
     delete this.symbols.functions['@getThis'];
+    delete this.symbols.functions['@RegExp'];
     delete this.symbols.functions.prior;
 
     // Top level expressions should never be to a snapshot reference - should
@@ -416,16 +420,7 @@ util.methods(Generator, {
       return exp;
 
     case 'var':
-      var valueType = exp.valueType;
-      exp = lookupVar(exp);
-      if (valueType) {
-        exp.valueType = valueType;
-      }
-      if (valueType == 'RegExp' && (exp.type != 'String' ||
-                                    !/\/.*\//.test(exp.value))) {
-        throw new Error(errors.coercion + decodeExpression(exp) + " => RegExp");
-      }
-      return exp;
+      return lookupVar(exp);
 
     case 'ref':
       var base;
@@ -517,7 +512,8 @@ util.methods(Generator, {
     }
   },
 
-  // Builtin function
+  // Builtin function - convert all this to 'data' (from 'newData').
+  // Args are function arguments, and params are the local (function) scope variables.
   prior: function(args, params) {
     var lastThisIs = this.thisIs;
     this.thisIs = 'data';
@@ -526,9 +522,22 @@ util.methods(Generator, {
     return exp;
   },
 
+  // Builtin function -
   getThis: function(args, params) {
     var result = ast.snapshotVariable(this.thisIs);
     return result;
+  },
+
+  // Builtin function - convert string to RegExp
+  makeRegExp: function(args, params) {
+    if (args.length != 1) {
+      throw new Error("RegExp application error.");
+    }
+    var exp = args[0];
+    if (exp.type != 'String' || !/\/.*\//.test(exp.value)) {
+      throw new Error(errors.coercion + decodeExpression(exp) + " => RegExp");
+    }
+    return ast.regexp(exp.value);
   },
 
   // Lookup globally defined function.
@@ -591,11 +600,12 @@ function decodeExpression(exp, outerPrecedence) {
     break;
 
   case 'String':
-    if (exp.valueType == 'RegExp') {
-      result = exp.value;
-    } else {
-      result = util.quoteString(exp.value);
-    }
+    result = util.quoteString(exp.value);
+    break;
+
+  // RegExp assumed to be in correct format.
+  case 'RegExp':
+    result = exp.value;
     break;
 
   case 'Null':

--- a/test/generator-test.js
+++ b/test/generator-test.js
@@ -20,7 +20,9 @@ var parse = bolt.parse;
 var fileio = require('file-io');
 var helper = require('./test-helper');
 
-var assert = require('chai').assert;
+var chai = require('chai');
+chai.config.truncateThreshold = 1000;
+var assert = chai.assert;
 
 // TODO: Test duplicated function, and schema definitions.
 // TODO: Test other parser errors - appropriate messages (exceptions).
@@ -166,21 +168,20 @@ suite("Rules Generator Tests", function() {
       { f: "",
         x: "this.foo || this.bar",
         expect: "newData.child('foo').val() == true || newData.child('bar').val() == true"},
-      // Don't support snapshot functions beyond parent.
+      // TODO: Don't support snapshot functions beyond parent.
       // TODO: Should warn user not to use Firebase builtins!
-      { f: "", x: "this.isString == 'a'", expect: "newData.child('isString').val() == 'a'" },
+      // { f: "", x: "this.isString()", expect: "newData.child('isString').val() == true" },
       { f: "function f(a) { return a == '123'; }", x: "f(this)", expect: "newData.val() == '123'" },
       { f: "function f(a) { return a == '123'; }",
         x: "f(this.foo)", expect: "newData.child('foo').val() == '123'" },
     ];
 
     helper.dataDrivenTest(tests, function(data, expect) {
-      var symbols = parse(data.f + " path /x { read() { return " + data.x + "; }}");
+      var symbols = parse(data.f + " path /x { write() { return " + data.x + "; }}");
       var gen = new bolt.Generator(symbols);
       // Make sure local Schema initialized.
-      gen.generateRules();
-      var decode = gen.getExpressionText(symbols.paths['/x'].methods.read.body);
-      assert.equal(decode, expect);
+      var json = gen.generateRules();
+      assert.equal(json.rules.x['.write'], expect);
     });
   });
 
@@ -215,12 +216,11 @@ suite("Rules Generator Tests", function() {
     ];
 
     helper.dataDrivenTest(tests, function testIt(data, expect) {
-      var symbols = parse("path /x { read() { return " + data + "; }}");
+      var symbols = parse("path /x { write() { return " + data + "; }}");
       var gen = new bolt.Generator(symbols);
       // Make sure local Schema initialized.
-      gen.generateRules();
-      var decode = gen.getExpressionText(symbols.paths['/x'].methods.read.body);
-      assert.equal(decode, expect);
+      var json = gen.generateRules();
+      assert.equal(json.rules.x['.write'], expect);
     });
   });
 
@@ -271,6 +271,12 @@ suite("Rules Generator Tests", function() {
         expect: "newData.child('x').isNumber() || newData.child('x').val() == null" },
       { data: "type Simple {n: Number, validate() {return this.n < 7;}}",
         expect: "newData.child('n').isNumber() && newData.child('n').val() < 7" },
+      { data: "type Bigger extends Number {" +
+        "validate() { return this == null || this > prior(this); }}" +
+        "type Simple { ts: Bigger }",
+        expect: "newData.child('ts').isNumber() && " +
+        "(newData.child('ts').val() == null || " +
+        "newData.child('ts').val() > data.child('ts').val())" }
     ];
 
     helper.dataDrivenTest(tests, function(data, expect) {

--- a/test/samples/mail.bolt
+++ b/test/samples/mail.bolt
@@ -21,8 +21,8 @@ path /users/$userid/inbox/$msg is Message {
   // Anyone can send a message to anybody by posting in the users inbox, as long as they have
   // the correct sender field.
   write() {
-    return isCreating(data) ||
-      isUpdating(data) && isCurrentUser($userid);
+    return isCreating(this) ||
+      isUpdating(this) && isCurrentUser($userid);
   }
 
 }
@@ -32,17 +32,17 @@ path /users/$userid/outbox/$msg is Message {
   read() { return isCurrentUser($userid); }
 
   write() {
-    return isCreating(data) ||
-      isUpdating(data) && isCurrentUser($userid);
+    return isCreating(this) ||
+      isUpdating(this) && isCurrentUser($userid);
   }
 }
 
 function isCreating(old) {
-  return old == null;
+  return prior(old) == null;
 }
 
 function isUpdating(old) {
-  return old != null;
+  return prior(old) != null;
 }
 
 function isCurrentUser(userid) {

--- a/test/samples/userdoc.bolt
+++ b/test/samples/userdoc.bolt
@@ -54,7 +54,7 @@ path /permissions {
 
 path /permissions/$key is Permission {
   write() {
-    return this == null && isCurrentUser(data.owner) ||
+    return this == null && isCurrentUser(prior(this.owner)) ||
       this != null &&
       // Limit structure of the key format to "grantee|owner|docid"
       $key == fullId(this.grantee, this.owner, this.docid) &&

--- a/tools/debug-tests
+++ b/tools/debug-tests
@@ -2,4 +2,4 @@
 # debug-tests --- Run unit tests in mocha under node debugger
 
 cd $PROJ_DIR
-mocha --ui tdd debug
+mocha --ui tdd debug "$@"


### PR DESCRIPTION
Don't use the Github button to merge this PR - it needs to be rebased after merging koss-refactor-tests (I can do it once reviewed).

The technique used here is to introduce a hidden function `@getThis` - which returns the root of either "newData" or "data" depending on context.  Functions are expanded inline first with no definition for `@getThis` (since we need to avoid prematurely binding the wrong variable.  We then make a 2nd pass (after all normal function expansion is complete), leaving only `@getThis` and `prior()` function calls, when arrange for the correct version of `this` to be returned.

This PR fixes Issue #33 and #35.