### PR TITLE
Terse variants for methods, paths, and type statements.  Fixes #39.

### DIFF
--- a/bin/firebase-bolt
+++ b/bin/firebase-bolt
@@ -31,7 +31,7 @@ process.stdin.on('end', function() {
 
   try {
     symbols = bolt.parse(input);
-  } catch(e) {
+  } catch (e) {
     console.error('bolt:' + e.line + ':' + e.column + ': ' + e.message);
     process.exit(1);
   }
@@ -39,7 +39,7 @@ process.stdin.on('end', function() {
   try {
     var gen = new bolt.Generator(symbols);
     rules = gen.generateRules();
-  } catch(e) {
+  } catch (e) {
     console.error('bolt: ' + e.message);
     process.exit(2);
   }

--- a/docs/language.md
+++ b/docs/language.md
@@ -34,7 +34,7 @@ A bolt file can also contain JavaScript-style comments:
 
 A path statement provides access and validation rules for data stored at a given path.
 
-    path /path/to/data [is Type] {
+    [path] /path/to/data [is Type] {
       read() {
         return <true-iff-reading-this-location-is-allowed>;
       }
@@ -58,6 +58,14 @@ within an expression as a variable parameter.
         return $wildcard < "Z" && $id > 7;
       }
     }
+
+If a path has no body the following form can be used:
+
+    path /top/$wildcard/$id is Type;
+
+or
+
+    /top/$wildcard/$id is Type;
 
 In expressions, the value of `this` is either the current value to `read()` or the new value to `write()`.
 
@@ -131,6 +139,13 @@ examples are identical and can be used interchangably.
     function myFunction(arg1, arg2) { arg1 == arg2.value }
 
     myFunction(arg1, arg2) = arg1 == arg2.value;
+
+Similarly, methods in path and type statement can use the abbreviated functional form (all
+these are equivalent):
+
+    write() { return this.user == auth.uid; }
+    write() { this.user == auth.uid }
+    write() = this.user == auth.uid;
 
 # Expressions
 

--- a/docs/language.md
+++ b/docs/language.md
@@ -140,7 +140,7 @@ examples are identical and can be used interchangably.
 
     myFunction(arg1, arg2) = arg1 == arg2.value;
 
-Similarly, methods in path and type statement can use the abbreviated functional form (all
+Similarly, methods in path and type statements can use the abbreviated functional form (all
 these are equivalent):
 
     write() { return this.user == auth.uid; }

--- a/test/parser-test.js
+++ b/test/parser-test.js
@@ -238,6 +238,59 @@ suite("Rules Parser Tests", function() {
     });
   });
 
+  suite("Method variations", function() {
+    var tests = [
+      "validate() { return this; }",
+      "validate() { return this  }",
+      "validate() { this; }",
+      "validate() { this }",
+      "validate() = this;",
+    ];
+
+    helper.dataDrivenTest(tests, function(data, expect) {
+      var result = parse("type T {" + data + "}");
+      assert.deepEqual(result.schema.T.methods.validate.body,
+                       ast.variable('this'));
+    });
+  });
+
+  suite("Path variations", function() {
+    var tests = [
+      "path /p/c {}",
+      "/p/c {}",
+      "/p/c;",
+      "path /p/c is String {}",
+      "path /p/c is String;",
+      "/p/c is String {}",
+      "/p/c is String;",
+      "/p/c { validate() { return true; } }",
+      "/p/c { validate() { return true } }",
+      "/p/c { validate() { true } }",
+      "/p/c { validate() = true; }",
+    ];
+
+    helper.dataDrivenTest(tests, function(data, expect) {
+      var result = parse(data);
+      assert.deepEqual(result.paths['/p/c'].parts,
+                       ['p', 'c']);
+    });
+  });
+
+  suite("Type variations", function() {
+    var tests = [
+      "type T extends Any {}",
+      "type T extends Any;",
+      "type T {}",
+      "type T;"
+    ];
+
+    helper.dataDrivenTest(tests, function(data, expect) {
+      var result = parse(data);
+      assert.deepEqual(result.schema.T,
+                       { derivedFrom: 'Any', methods: {}, properties: {} });
+    });
+  });
+
   suite("Sample files", function() {
     var files = [
       "all_access",


### PR DESCRIPTION
This PR relaxes some of the requirements for extraneous syntax in methods, path statments, and type statements.

- Allow ";" in lieu of "{}" (empty body) for path and type statements.
- Allow "path" to be optional (as in original language proposal).
- As in terse function syntax, allow methods to be `fn() = exp;` instead of `fn() { exp }`

This is all syntactic sugar - there is no change to the AST using these new forms.

@tomlarkworthy @matjaz 