### PR TITLE
Use validator tree of expressions and enforce no un-named properties.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,7 +32,8 @@ var JS_SOURCES = ['gulpfile.js',
                   'bin/firebase-bolt',
                   'test/*.js'];
 
-var TEST_FILES = ['test/generator-test.js', 'test/parser-test.js'];
+var TEST_FILES = ['test/generator-test.js', 'test/parser-test.js',
+                  'test/ast-test.js', 'test/util-test.js'];
 
 gulp.task('lint', function() {
   return gulp.src(JS_SOURCES.concat(['!lib/rules-parser.js']))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -72,12 +72,12 @@ gulp.task('browserify', ['browserify-bolt',
                          'browserify-mail-test']);
 
 // Runs the Mocha test suite
-gulp.task('test', ['build'], function() {
+gulp.task('test', ['lint', 'build'], function() {
   return gulp.src(TEST_FILES)
     .pipe(mocha({ui: 'tdd'}));
 });
 
-gulp.task('default', ['lint', 'build', 'test']);
+gulp.task('default', ['test']);
 
 function browserifyToDist(entry, opts) {
   // Browserify options include:

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -72,7 +72,6 @@ module.exports = {
 
   // Type operators
   'typeType': typeType,
-  'genericType': genericType,
   'unionType': unionType,
 
   'getTypeNames': getTypeNames,
@@ -248,10 +247,6 @@ function typeType(typeName) {
   return { type: "type", name: typeName };
 }
 
-function genericType(baseType, params) {
-  return { type: "generic", baseType: baseType, params: params };
-}
-
 function unionType(types) {
   return { type: "union", types: types };
 }
@@ -262,8 +257,8 @@ function getTypeNames(type) {
     return [type.name];
   case 'union':
     return type.types.map(getTypeNames).reduce(util.extendArray);
-  case 'generic':
-    throw new Error("NYI");
+  default:
+    throw new Error("Unknown type: " + type.type);
   }
 }
 

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -48,6 +48,7 @@ module.exports = {
   'array': valueGen('Array'),
   'regexp': valueGen('RegExp'),
 
+  'op': op,
   'neg': opGen('neg', 1),
   'not': opGen('!', 1),
   'mult': opGen('*'),
@@ -66,10 +67,15 @@ module.exports = {
   'ternary': opGen('?:', 3),
   'value': opGen('value', 1),
 
-  'andArray': leftAssociateGen('&&', boolean(true)),
-  'orArray': leftAssociateGen('||', boolean(false)),
+  'andArray': leftAssociateGen('&&', boolean(true), boolean(false)),
+  'orArray': leftAssociateGen('||', boolean(false), boolean(true)),
 
-  'op': op,
+  // Type operators
+  'typeType': typeType,
+  'genericType': genericType,
+  'unionType': unionType,
+
+  'getTypeNames': getTypeNames,
 
   'Symbols': Symbols
 };
@@ -167,12 +173,12 @@ function isCall(exp, methodName) {
 }
 
 // Return value generating function for a given Type.
-function valueGen(type) {
+function valueGen(typeName) {
   return function(value) {
     return {
-      type: type,         // Exp type identifying a constant value of this Type.
-      valueType: type,    // The type of the result of evaluating this expression.
-      value: value        // The (constant) value itself.
+      type: typeName,      // Exp type identifying a constant value of this Type.
+      valueType: typeName, // The type of the result of evaluating this expression.
+      value: value         // The (constant) value itself.
     };
   };
 }
@@ -193,22 +199,31 @@ function opGen(opType, arity) {
 
 // A reducing function for binary operators - use with [].reduce
 // initialValue's in array are ignored (or returned for empty array).
-function leftAssociateGen(opType, initialValue) {
-  function reducer(result, current) {
-    if (result === undefined) {
-      return current;
-    }
-    if (current.type == initialValue.type && current.value == initialValue.value) {
-      return result;
-    }
-    return op(opType, [result, current]);
-  }
-
+function leftAssociateGen(opType, initialValue, shortcutValue) {
   return function(a) {
-    if (a.length == 0) {
+    function reducer(result, current) {
+      if (result === undefined) {
+        return current;
+      }
+      return op(opType, [result, current]);
+    }
+
+    var result = [];
+    for (var i = 0; i < a.length; i++) {
+      if (a[i].type == initialValue.type && a[i].value == initialValue.value) {
+        continue;
+      }
+      if (a[i].type == shortcutValue.type && a[i].value == shortcutValue.value) {
+        return shortcutValue;
+      }
+      result.push(a[i]);
+    }
+
+    if (result.length == 0) {
       return initialValue;
     }
-    return a.reduce(reducer);
+
+    return result.reduce(reducer);
   };
 }
 
@@ -227,6 +242,29 @@ function method(params, body) {
     params: params,
     body: body
   };
+}
+
+function typeType(typeName) {
+  return { type: "type", name: typeName };
+}
+
+function genericType(baseType, params) {
+  return { type: "generic", baseType: baseType, params: params };
+}
+
+function unionType(types) {
+  return { type: "union", types: types };
+}
+
+function getTypeNames(type) {
+  switch (type.type) {
+  case 'type':
+    return [type.name];
+  case 'union':
+    return type.types.map(getTypeNames).reduce(util.extendArray);
+  case 'generic':
+    throw new Error("NYI");
+  }
 }
 
 function Symbols() {
@@ -259,7 +297,7 @@ util.methods(Symbols, {
   registerPath: function(parts, isType, methods) {
     methods = methods || {};
 
-    isType = isType || 'Any';
+    isType = isType || typeType('Any');
     var p = {
       parts: parts,
       isType: isType,
@@ -272,7 +310,7 @@ util.methods(Symbols, {
     methods = methods || {};
     properties = properties || {};
 
-    derivedFrom = derivedFrom || (Object.keys(properties).length > 0 ? 'Object' : 'Any');
+    derivedFrom = derivedFrom || typeType(Object.keys(properties).length > 0 ? 'Object' : 'Any');
     var s = {
       derivedFrom: derivedFrom,
       properties: properties,
@@ -298,7 +336,7 @@ util.methods(Symbols, {
     if (!schema) {
       return false;
     }
-    return this.isDerivedFrom(schema.derivedFrom, ancestor, visited);
+    return this.isDerivedFrom(schema.derivedFrom.name, ancestor, visited);
   },
 
   setLoggers: function(loggers) {

--- a/lib/rules-generator.js
+++ b/lib/rules-generator.js
@@ -20,7 +20,9 @@ var ast = require('./ast');
 
 module.exports = {
   'Generator': Generator,
-  'decodeExpression': decodeExpression
+  'decodeExpression': decodeExpression,
+  'extendValidator': extendValidator,
+  'mapValidator': mapValidator,
 };
 
 var errors = {
@@ -36,6 +38,7 @@ var errors = {
   badPathMethod: "Unsupported method name in path statement: ",
   coercion: "Cannot convert value: ",
   undefinedFunction: "Undefined function: ",
+  application: "Bolt application error: ",
 };
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence
@@ -78,6 +81,7 @@ var snapshotMethods = ['parent', 'child', 'hasChildren', 'val', 'isString', 'isN
 function Generator(symbols) {
   this.symbols = symbols;
   this.log = symbols.log;
+  this.validators = {};
   this.rules = {};
   this.errorCount = 0;
   this.runSilently = false;
@@ -112,7 +116,7 @@ util.methods(Generator, {
     }
 
     for (var schemaName in this.symbols.schema) {
-      this.registerSchemaValidator(schemaName);
+      this.ensureValidator(schemaName);
     }
 
 
@@ -123,10 +127,13 @@ util.methods(Generator, {
     for (var pathName in paths) {
       this.updateRules(paths[pathName]);
     }
+    this.convertExpressions(this.rules);
 
     if (this.errorCount != 0) {
       throw new Error(errors.generateFailed + this.errorCount + " errors.");
     }
+
+    util.pruneEmptyChildren(this.rules);
 
     return {
       rules: this.rules
@@ -142,10 +149,12 @@ util.methods(Generator, {
     }
   },
 
-  validateType: function(typeName) {
-    if (!(typeName in this.symbols.schema)) {
-      this.fatal(errors.noSuchType + util.quoteString(typeName));
-    }
+  validateType: function(type) {
+    ast.getTypeNames(type).forEach(function(typeName) {
+      if (!(typeName in this.symbols.schema)) {
+        this.fatal(errors.noSuchType + util.quoteString(typeName));
+      }
+    }.bind(this));
   },
 
   registerBuiltinSchema: function() {
@@ -153,21 +162,28 @@ util.methods(Generator, {
     var thisVar = ast.variable('this');
 
     function registerAsCall(name, methodName) {
-      self.symbols.registerSchema(name, 'Any', undefined, {
+      self.symbols.registerSchema(name, ast.typeType('Any'), undefined, {
         validate: ast.method(['this'], ast.call(ast.reference(ast.cast(thisVar, 'Any'),
                                                               methodName)))
       });
     }
 
-    this.symbols.registerSchema('Any', 'Any', undefined, {
+    this.symbols.registerSchema('Any', ast.typeType('Any'), undefined, {
       validate: ast.method(['this'], ast.boolean(true))
     });
 
-    this.symbols.registerSchema('Null', 'Any', undefined, {
+    /*
+    this.symbols.registerSchema('Object', ast.typeType('Any'), undefined, {
+      validate: ast.method(['this'], ast.boolean(true))
+    });
+    */
+    registerAsCall('Object', 'hasChildren');
+
+    this.symbols.registerSchema('Null', ast.typeType('Any'), undefined, {
       validate: ast.method(['this'], ast.eq(thisVar, ast.nullType()))
     });
 
-    self.symbols.registerSchema('String', 'Any', undefined, {
+    self.symbols.registerSchema('String', ast.typeType('Any'), undefined, {
       validate: ast.method(['this'],
                            ast.call(ast.reference(ast.cast(thisVar, 'Any'), 'isString'))),
       includes: ast.method(['this', 's'],
@@ -187,93 +203,102 @@ util.methods(Generator, {
                                 [ ast.call(ast.variable('@RegExp'), [ast.variable('s')]) ])),
     });
 
-    registerAsCall('Object', 'hasChildren');
     registerAsCall('Number', 'isNumber');
     registerAsCall('Boolean', 'isBoolean');
+
+    this.symbols.registerFunction('@RegExp', ['s'],
+                                  ast.builtin(this.makeRegExp.bind(this)));
   },
 
-  // Return a validator expression that returns true iff
-  // *this* conforms to the defined schema:
-  // 1. Conforms to derivedFrom schema. &&
-  // 2. Each property in properties conforms to it's type.
-  // 3. Conforms to the validate method.
-  registerSchemaValidator: function(schemaName) {
+  // Ensure we have a definition for a validator for the given schema.
+  ensureValidator: function(schemaName) {
+    // TODO: Guard against recursion
+    if (!this.validators[schemaName]) {
+      this.validators[schemaName] = this.createValidator(schemaName);
+      // console.log(schemaName + ": " + util.prettyJSON(this.validators[schemaName]));
+    }
+    return this.validators[schemaName];
+  },
+
+  // A validator is a structured object, where each leaf node
+  // is:
+  //     ".validate": [<expression>, ...]
+  // All expressions will be ANDed together to form the file expresion.
+  // Intermediate nodes can be "prop" or "$prop" values.
+  createValidator: function(schemaName) {
     var schema = this.symbols.schema[schemaName];
-    var terms = [];
-    var thisVar = ast.variable('this');
+    var validator = {};
+
+    if (!schema) {
+      throw new Error(errors.application + "Undefined schema: " + schemaName);
+    }
 
     var hasProps = Object.keys(schema.properties).length > 0;
 
     if (hasProps && !this.symbols.isDerivedFrom(schemaName, 'Object')) {
-      this.fatal(errors.nonObject + " (" + schemaName + " is " + schema.derivedFrom + ")");
-      return;
+      this.fatal(errors.nonObject + " (" + schemaName + " is " + schema.derivedFrom.name + ")");
+      return {};
     }
 
-    // @validator@<T>(this)
-    if (schema.derivedFrom != 'Any' && !hasProps) {
-      terms.push(ast.call(ast.variable('@validator@' + schema.derivedFrom),
-                          [ thisVar ]));
+    if (schema.derivedFrom.name != 'Any') {
+      extendValidator(validator, this.ensureValidator(schema.derivedFrom.name));
     }
 
-    for (var propName in schema.properties) {
-      var property = schema.properties[propName];
-      var propTerms = [];
-      for (var i = 0; i < property.types.length; i++) {
-        var type = property.types[i];
-        // @validator@<type>(this[propName])
-        propTerms.push(ast.call(ast.variable('@validator@' + type),
-                                [ ast.reference(thisVar, propName) ]));
+    var requiredProperties = [];
+    Object.keys(schema.properties).forEach(function(propName) {
+      if (!validator[propName]) {
+        validator[propName] = {};
       }
-      if (propTerms.length > 0) {
-        terms.push(ast.orArray(propTerms));
+      var propType = schema.properties[propName];
+      var propSchema = ast.getTypeNames(propType);
+      if (!util.arrayIncludes(propSchema, 'Null')) {
+        requiredProperties.push(propName);
       }
+      extendValidator(validator[propName], this.unionValidators(propSchema));
+    }.bind(this));
+
+    if (requiredProperties.length > 0) {
+      // this.hasChildren(requiredProperties)
+      extendValidator(validator,
+                      {'.validate': [hasChildrenExp(requiredProperties)]});
+    }
+
+    if (hasProps) {
+      validator['$other'] = {};
+      extendValidator(validator['$other'], {'.validate': ast.boolean(false)});
     }
 
     if (schema.methods.validate) {
-      terms.push(schema.methods.validate.body);
+      extendValidator(validator, {'.validate': [schema.methods.validate.body]});
     }
 
-    if (terms.length == 0) {
-      terms.push(ast.boolean(true));
-    }
-
-    var exp = ast.andArray(terms);
-    this.registerValidator(schemaName, exp);
-  },
-
-  // TODO: Store validators in this.symbols.schema[type].methods.validateAll
-  registerValidator: function(type, exp) {
-    this.symbols.registerFunction('@validator@' + type, ['this'], exp);
+    return validator;
   },
 
   // Update rules based on the given path expression.
   updateRules: function(path) {
     var i;
-    var location = this.ensurePath(path.parts);
+    var location = util.ensureObjectPath(this.rules, path.parts);
     var exp;
 
     // Path validation function && Type Validation
-    var terms = [];
     if (path.methods.validate) {
-      terms.push(path.methods.validate.body);
+      extendValidator(location, {'.validate': [path.methods.validate.body]});
     }
-    terms.push(this.symbols.functions['@validator@' + path.isType].body);
-    exp = ast.andArray(terms);
 
-    if (!(exp.type == 'Boolean' && exp.value == true)) {
-      location['.validate'] = this.getExpressionText(exp, 'newData');
-    }
+    ast.getTypeNames(path.isType).forEach(function(typeName) {
+      extendValidator(location, this.validators[typeName]);
+    }.bind(this));
 
     // Write .read and .write expressions
-    [{ method: 'read', thisIs: 'data'},
-     { method: 'write', thisIs: 'newData' }].forEach(function(methodInfo) {
-       if (path.methods[methodInfo.method]) {
-         exp = path.methods[methodInfo.method].body;
-         if (!(exp.type == 'Boolean' && exp.value == false)) {
-           location['.' + methodInfo.method] = this.getExpressionText(exp, methodInfo.thisIs);
-         }
-       }
-     }.bind(this));
+    ['read', 'write'].forEach(function(method) {
+      if (path.methods[method]) {
+        var validator = {};
+        // TODO: What if two paths overwrite the same location?
+        validator['.' + method] = [path.methods[method].body];
+        extendValidator(location, validator);
+      }
+    });
 
     // Write indices
     if (path.methods.index) {
@@ -296,11 +321,51 @@ util.methods(Generator, {
           indices.push(exp.value[i].value);
         }
       }
+      // TODO: Error check not over-writing index rules.
       location['.indexOn'] = indices;
     }
   },
 
+  // Return union validator (||) over each schema
+  unionValidators: function(schema) {
+    var union = {};
+    schema.forEach(function(typeName) {
+      // First and the validator terms for a single type
+      var singleType = extendValidator({}, this.ensureValidator(typeName));
+      mapValidator(singleType, ast.andArray);
+      extendValidator(union, singleType);
+    }.bind(this));
+    mapValidator(union, ast.orArray);
+    return union;
+  },
+
+  convertExpressions: function(validator, thisIs) {
+    var methodThisIs = { '.validate': 'newData',
+                         '.read': 'data',
+                         '.write': 'newData' };
+
+    mapValidator(validator, function(value, prop) {
+      if (prop in methodThisIs) {
+        var isObjectIndex = findCaller(value, 'hasChildren', false);
+        var hasChildrenIndex = findCaller(value, 'hasChildren', true);
+        if (isObjectIndex != -1 && hasChildrenIndex != -1) {
+          value.splice(isObjectIndex, 1);
+        }
+        value = collapseHasChildren(value);
+        value = this.getExpressionText(ast.andArray(value), methodThisIs[prop]);
+        if (prop == '.validate' && value == 'true' ||
+            (prop == '.read' || prop == '.write') && value == 'false') {
+          value = undefined;
+        }
+      }
+      return value;
+    }.bind(this));
+  },
+
   getExpressionText: function(exp, thisIs) {
+    if (!('type' in exp)) {
+      throw new Error(errors.application + "Not an expression: " + util.prettyJSON(exp));
+    }
     // First evaluate w/o binding of this to specific location.
     this.allowUndefinedFunctions = true;
     exp = this.partialEval(exp, { 'this': ast.cast(ast.call(ast.variable('@getThis')),
@@ -310,33 +375,18 @@ util.methods(Generator, {
     this.thisIs = thisIs || 'newData';
     this.symbols.registerFunction('@getThis', [],
                                   ast.builtin(this.getThis.bind(this)));
-    this.symbols.registerFunction('@RegExp', ['s'],
-                                  ast.builtin(this.makeRegExp.bind(this)));
     this.symbols.registerFunction('prior', ['exp'],
                                   ast.builtin(this.prior.bind(this)));
 
     exp = this.partialEval(exp);
 
     delete this.symbols.functions['@getThis'];
-    delete this.symbols.functions['@RegExp'];
     delete this.symbols.functions.prior;
 
     // Top level expressions should never be to a snapshot reference - should
     // always evaluate to a boolean.
     exp = ast.ensureBoolean(exp);
     return decodeExpression(exp);
-  },
-
-  ensurePath: function(parts) {
-    var obj = this.rules;
-    for (var i = 0; i < parts.length; i++) {
-      var name = parts[i];
-      if (!(name in obj)) {
-        obj[name] = {};
-      }
-      obj = obj[name];
-    }
-    return obj;
   },
 
   // Partial evaluation of expressions - copy of expression tree (immutable).
@@ -513,7 +563,7 @@ util.methods(Generator, {
     }
   },
 
-  // Builtin function - convert all this to 'data' (from 'newData').
+  // Builtin function - convert all 'this' to 'data' (from 'newData').
   // Args are function arguments, and params are the local (function) scope variables.
   prior: function(args, params) {
     var lastThisIs = this.thisIs;
@@ -523,7 +573,7 @@ util.methods(Generator, {
     return exp;
   },
 
-  // Builtin function -
+  // Builtin function - current value of 'this'
   getThis: function(args, params) {
     var result = ast.snapshotVariable(this.thisIs);
     return result;
@@ -532,9 +582,9 @@ util.methods(Generator, {
   // Builtin function - convert string to RegExp
   makeRegExp: function(args, params) {
     if (args.length != 1) {
-      throw new Error("RegExp application error.");
+      throw new Error(errors.application + "RegExp arguments.");
     }
-    var exp = args[0];
+    var exp = this.partialEval(args[0], params);
     if (exp.type != 'String' || !/\/.*\//.test(exp.value)) {
       throw new Error(errors.coercion + decodeExpression(exp) + " => RegExp");
     }
@@ -690,4 +740,105 @@ function precedenceOf(exp) {
   default:
     return 19;
   }
+}
+
+// Merge all .X terms into target.
+function extendValidator(target, src) {
+  if (src === undefined) {
+    throw new Error(errors.application + "Illegal validation source.");
+  }
+  for (var prop in src) {
+    if (!src.hasOwnProperty(prop)) {
+      continue;
+    }
+    if (prop[0] == '.') {
+      if (target[prop] == undefined) {
+        target[prop] = [];
+      }
+      if (util.isType(src[prop], 'array')) {
+        util.extendArray(target[prop], src[prop]);
+      } else {
+        target[prop].push(src[prop]);
+      }
+    } else {
+      if (!target[prop]) {
+        target[prop] = {};
+      }
+      extendValidator(target[prop], src[prop]);
+    }
+  }
+
+  return target;
+}
+
+// Call fn(value, prop) on all '.props' and assiging the value back into the
+// validator.
+function mapValidator(v, fn) {
+  for (var prop in v) {
+    if (!v.hasOwnProperty(prop)) {
+      continue;
+    }
+    if (prop[0] == '.') {
+      v[prop] = fn(v[prop], prop);
+      if (v[prop] === undefined) {
+        delete v[prop];
+      }
+    } else {
+      mapValidator(v[prop], fn);
+    }
+  }
+}
+
+// Find a function call to a method in an array of expressions.
+function findCaller(exps, methodName, hasArgs) {
+  for (var i = 0; i < exps.length; i++) {
+    var exp = exps[i];
+    if (exp.type == 'call' && (hasArgs ? exp.args.length > 0 : exp.args.length == 0) &&
+        exp.ref.type == 'ref' && exp.ref.accessor == methodName) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+// Collapse all hasChildren calls into one (combining their arguments).
+// E.g. newData.hasChildren() && newData.hasChildren(['x']) && newData.hasChildren(['y']) =>
+//      newData.hasChildren(['x', 'y'])
+function collapseHasChildren(exps) {
+  var hasHasChildren = false;
+  var combined = [];
+  var result = [];
+  exps.forEach(function(exp) {
+    if (exp.type == 'call' && exp.ref.type == 'ref' && exp.ref.accessor == 'hasChildren') {
+      if (exp.args.length == 0) {
+        hasHasChildren = true;
+        return;
+      }
+      // Expect one argument of Array type.
+      if (exp.args.length != 1 || exp.args[0].type != 'Array') {
+        throw new Error(errors.application + "Invalid argument to hasChildren(): " +
+                        exp.args[0].type);
+      }
+      exp.args[0].value.forEach(function(arg) {
+        hasHasChildren = true;
+        if (arg.type != 'String') {
+          throw new Error(errors.application + "Expect string argument to hasChildren(), not: " +
+                          arg.type);
+        }
+        combined.push(arg.value);
+      });
+    } else {
+      result.push(exp);
+    }
+  });
+  if (hasHasChildren) {
+    result.unshift(hasChildrenExp(combined));
+  }
+  return result;
+}
+
+// Generate this.hasChildren([props, ...])
+function hasChildrenExp(props) {
+  var args = props.length == 0 ? [] : [ast.array(props.map(ast.string))];
+  return ast.call(ast.reference(ast.cast(ast.variable('this'), 'Any'), 'hasChildren'), args);
 }

--- a/lib/rules-generator.js
+++ b/lib/rules-generator.js
@@ -346,11 +346,6 @@ util.methods(Generator, {
 
     mapValidator(validator, function(value, prop) {
       if (prop in methodThisIs) {
-        var isObjectIndex = findCaller(value, 'hasChildren', false);
-        var hasChildrenIndex = findCaller(value, 'hasChildren', true);
-        if (isObjectIndex != -1 && hasChildrenIndex != -1) {
-          value.splice(isObjectIndex, 1);
-        }
         value = collapseHasChildren(value);
         value = this.getExpressionText(ast.andArray(value), methodThisIs[prop]);
         if (prop == '.validate' && value == 'true' ||
@@ -787,18 +782,6 @@ function mapValidator(v, fn) {
       mapValidator(v[prop], fn);
     }
   }
-}
-
-// Find a function call to a method in an array of expressions.
-function findCaller(exps, methodName, hasArgs) {
-  for (var i = 0; i < exps.length; i++) {
-    var exp = exps[i];
-    if (exp.type == 'call' && (hasArgs ? exp.args.length > 0 : exp.args.length == 0) &&
-        exp.ref.type == 'ref' && exp.ref.accessor == methodName) {
-      return i;
-    }
-  }
-  return -1;
 }
 
 // Collapse all hasChildren calls into one (combining their arguments).

--- a/lib/simulator.js
+++ b/lib/simulator.js
@@ -29,6 +29,8 @@ var bolt = (typeof window != 'undefined' && window.bolt) || require('./bolt');
 var util = require('./util');
 var fileIO = require('./file-io');
 
+var MAX_TEST_MS = 30000;
+
 module.exports = {
   rulesSuite: rulesSuite
 };
@@ -59,7 +61,7 @@ util.methods(RulesSuite, {
 
     // Run Mocha Test Suite - serialize with any other mocha test suites.
     suite("Firebase Rules Simulator: " + self.suiteName, function() {
-      this.timeout(10000);
+      this.timeout(MAX_TEST_MS);
       suiteSetup(function() {
         var rulesPath = new Promise(function(resolve) {
           self.rulesPathResolve = resolve;

--- a/lib/util.js
+++ b/lib/util.js
@@ -17,6 +17,7 @@ var Promise = require('promise');
 
 module.exports = {
   'extend': extend,
+  'extendArray': extendArray,
   'methods': methods,
   'copyArray': copyArray,
   'arrayIncludes': arrayIncludes,
@@ -29,6 +30,8 @@ module.exports = {
   'prettyJSON': prettyJSON,
   'deepExtend': deepExtend,
   'quoteString': quoteString,
+  'ensureObjectPath': ensureObjectPath,
+  'pruneEmptyChildren': pruneEmptyChildren,
 };
 
 function methods(ctor, obj) {
@@ -164,4 +167,43 @@ function quoteString(s) {
 
 function arrayIncludes(a, e) {
   return a.indexOf(e) != -1;
+}
+
+// Like Python list.extend
+function extendArray(target, src) {
+  if (target === undefined) {
+    target = [];
+  }
+  Array.prototype.push.apply(target, src);
+  return target;
+}
+
+function ensureObjectPath(obj, parts) {
+  for (var i = 0; i < parts.length; i++) {
+    var name = parts[i];
+    if (!(name in obj)) {
+      obj[name] = {};
+    }
+    obj = obj[name];
+  }
+  return obj;
+}
+
+// Remove all empty, '{}',  children - returns true iff obj is empty.
+function pruneEmptyChildren(obj) {
+  if (obj.constructor != Object) {
+    return false;
+  }
+  var hasChildren = false;
+  for (var prop in obj) {
+    if (!obj.hasOwnProperty(prop)) {
+      continue;
+    }
+    if (pruneEmptyChildren(obj[prop])) {
+      delete obj[prop];
+    } else {
+      hasChildren = true;
+    }
+  }
+  return !hasChildren;
 }

--- a/src/rules-parser.pegjs
+++ b/src/rules-parser.pegjs
@@ -207,14 +207,8 @@ TypeExpression  = head:SingleType tail:(_ "|" _ type:SingleType { return type; }
 
 // Type, Type[], or Type<X, ... >
 // Type[] === Map<String, Type>
-SingleType = type:Identifier opt:(isMap:("\[\]") / "<" _ types:TypeList _ ">")? _ {
-  if (!opt) {
-    return ast.typeType(type);
-  }
-  if (opt.isMap) {
-    return ast.genericType('Map', ['String', type]);
-  }
-  return ast.genericType(type, opt.types);
+SingleType = type:Identifier _ {
+  return ast.typeType(type);
 }
 
 TypeList = head:SingleType tail:(_ "," _ type:SingleType { return type; })* _ {

--- a/src/rules-parser.pegjs
+++ b/src/rules-parser.pegjs
@@ -211,15 +211,6 @@ SingleType = type:Identifier _ {
   return ast.typeType(type);
 }
 
-TypeList = head:SingleType tail:(_ "," _ type:SingleType { return type; })* _ {
-  var result = [ensureUpperCase(head)];
-    for (var i = 0; i < tail.length; i++) {
-      result.push(ensureUpperCase(tail[i], "Type names"));
-    }
-    return result;
-}
-
-
 // ======================================
 // Expressions
 // ======================================

--- a/test/ast-test.js
+++ b/test/ast-test.js
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"use strict";
+
+var assert = require('chai').assert;
+var helper = require('./test-helper');
+
+var ast = require('../lib/ast');
+var gen = require('../lib/rules-generator');
+var util = require('../lib/util');
+
+suite("Abstract Syntax Tree (AST)", function() {
+  suite("Left Associative Operators (AND OR)", function() {
+    var t = ast.boolean(true);
+    var f = ast.boolean(false);
+    var v = ast.variable('v');
+
+    var tests = [
+      { data: [],
+        expect: {and: t, or: f} },
+      { data: [t],
+        expect: {and: t, or: t} },
+      { data: [f],
+        expect: {and: f, or: f} },
+      { data: [f, t],
+        expect: {and: f, or: t} },
+      { data: [t, f],
+        expect: {and: f, or: t} },
+      { data: [t, f, t],
+        expect: {and: f, or: t} },
+      { data: [f, t, f],
+        expect: {and: f, or: t} },
+      { data: [v],
+        expect: {and: v, or: v} },
+      { data: [v, t],
+        expect: {and: v, or: t} },
+      { data: [v, f],
+        expect: {and: f, or: v} },
+      { data: [t, v],
+        expect: {and: v, or: t} },
+      { data: [f, v],
+        expect: {and: f, or: v} },
+      { data: [t, v, f],
+        expect: {and: f, or: t} },
+      { data: [f, v, t],
+        expect: {and: f, or: t} },
+      { data: [v, f, v],
+        expect: {and: f, or: ast.or(v, v)} },
+      { data: [v, t, v],
+        expect: {and: ast.and(v, v), or: t} },
+    ];
+
+    function formatter(x) {
+      if (util.isType(x, 'array')) {
+        return '[' + x.map(formatter).join(', ') + ']';
+      }
+      if (util.isType(x, 'object')) {
+        if ('type' in x) {
+          return gen.decodeExpression(x);
+        }
+        var result = '{';
+        var sep = '';
+        for (var prop in x) {
+          result += sep + formatter(x[prop]);
+          sep = ', ';
+        }
+        result += '}';
+        return result;
+      }
+      return JSON.stringify(x);
+    }
+
+    helper.dataDrivenTest(tests, function(data, expect) {
+      assert.deepEqual(ast.andArray(data), expect.and, 'AND');
+      assert.deepEqual(ast.orArray(data), expect.or, 'OR');
+    }, formatter);
+  });
+});

--- a/test/generator-test.js
+++ b/test/generator-test.js
@@ -65,6 +65,7 @@ suite("Rules Generator Tests", function() {
                  "type-extension",
                  "children",
                  "functional",
+                 "user-security",
                 ];
 
     helper.dataDrivenTest(files, function(filename) {

--- a/test/generator-test.js
+++ b/test/generator-test.js
@@ -17,6 +17,8 @@
 
 var bolt = (typeof(window) != 'undefined' && window.bolt) || require('../lib/bolt');
 var parse = bolt.parse;
+var generator = require('../lib/rules-generator');
+var ast = require('../lib/ast');
 var fileio = require('../lib/file-io');
 var helper = require('./test-helper');
 
@@ -61,7 +63,8 @@ suite("Rules Generator Tests", function() {
                  "userdoc",
                  "mail",
                  "type-extension",
-                 "functional"
+                 "children",
+                 "functional",
                 ];
 
     helper.dataDrivenTest(files, function(filename) {
@@ -220,7 +223,7 @@ suite("Rules Generator Tests", function() {
         expect: "'ababa'.matches(/bab/)" },
     ];
 
-    helper.dataDrivenTest(tests, function testIt(data, expect) {
+    helper.dataDrivenTest(tests, function(data, expect) {
       var symbols = parse("path /x { write() { return " + data + "; }}");
       var gen = new bolt.Generator(symbols);
       // Make sure local Schema initialized.
@@ -229,70 +232,143 @@ suite("Rules Generator Tests", function() {
     });
   });
 
-  test("Builtin validation functions", function() {
-    var symbols = parse("path / {}");
-    var gen = new bolt.Generator(symbols);
-    gen.generateRules();
-    var baseTypes = ['String', 'Number', 'Boolean'];
-    assert.equal(gen.getExpressionText(symbols.functions['@validator@Object'].body),
-                 'newData.hasChildren()', 'Object');
-    assert.equal(gen.getExpressionText(symbols.functions['@validator@Null'].body),
-                 'newData.val() == null', 'Null');
-    assert.equal(gen.getExpressionText(symbols.functions['@validator@Any'].body),
-                 'true', 'Any');
-    for (var i = 0; i < baseTypes.length; i++) {
-      var type = baseTypes[i];
-      assert.equal(gen.getExpressionText(symbols.functions['@validator@' + type].body),
-                   'newData.is' + type.toUpperCase()[0] + type.slice(1) + '()', type);
-    }
+  suite("Builtin validation functions", function() {
+    var tests = [
+      [ 'String', 'this.isString()'],
+      [ 'Number', 'this.isNumber()'],
+      [ 'Boolean', 'this.isBoolean()'],
+      [ 'Object', 'this.hasChildren()'],
+      [ 'Null', 'this == null'],
+    ];
+
+    helper.dataDrivenTest(tests, function(data, expect) {
+      var symbols = parse("path / {}");
+      var gen = new bolt.Generator(symbols);
+      gen.generateRules();
+
+      var terms = gen.validators[data]['.validate'];
+      var result = bolt.decodeExpression(ast.andArray(terms));
+      assert.deepEqual(result, expect);
+    });
   });
 
   suite("Schema Validation", function() {
     var tests = [
-      { data: "type Simple {}",
+      { data: "type T {}",
         expect: undefined },
-      { data: "type Simple extends Object {}",
-        expect: "newData.hasChildren()" },
-      { data: "type Simple extends String {}",
-        expect: "newData.isString()" },
-      { data: "type Simple extends String { validate() { return this.length > 0; } }",
-        expect: "newData.isString() && newData.val().length > 0" },
+      { data: "type T extends Object {}",
+        expect: {'.validate': "newData.hasChildren()"} },
+      { data: "type T extends String {}",
+        expect: {'.validate': "newData.isString()"} },
+      { data: "type T extends String { validate() { return this.length > 0; } }",
+        expect: {'.validate': "newData.isString() && newData.val().length > 0"} },
       { data: "type NonEmpty extends String { validate() { return this.length > 0; } } \
-            type Simple { prop: NonEmpty }",
-        expect: "newData.child('prop').isString() && newData.child('prop').val().length > 0" },
-      { data: "type Simple {n: Number}",
-        expect: "newData.child('n').isNumber()" },
-      { data: "type Simple {s: String}",
-        expect: "newData.child('s').isString()" },
-      { data: "type Simple {b: Boolean}",
-        expect: "newData.child('b').isBoolean()" },
-      { data: "type Simple {x: Object}",
-        expect: "newData.child('x').hasChildren()" },
-      { data: "type Simple {x: Number|String}",
-        expect: "newData.child('x').isNumber() || newData.child('x').isString()" },
-      { data: "type Simple {a: Number, b: String}",
-        expect: "newData.child('a').isNumber() && newData.child('b').isString()" },
-      { data: "type Simple {x: Number|Null}",
-        expect: "newData.child('x').isNumber() || newData.child('x').val() == null" },
-      { data: "type Simple {n: Number, validate() {return this.n < 7;}}",
-        expect: "newData.child('n').isNumber() && newData.child('n').val() < 7" },
-      { data: "type Bigger extends Number {" +
-        "validate() { return this == null || this > prior(this); }}" +
-        "type Simple { ts: Bigger }",
-        expect: "newData.child('ts').isNumber() && " +
-        "(newData.child('ts').val() == null || " +
-        "newData.child('ts').val() > data.child('ts').val())" }
+            type T { prop: NonEmpty }",
+        expect: {'.validate': "newData.hasChildren(['prop'])",
+                 prop: {
+                   '.validate': 'newData.isString() && newData.val().length > 0'
+                 },
+                 '$other': {'.validate': "false"}
+                } },
+      { data: "type T {n: Number}",
+        expect: {'.validate': "newData.hasChildren(['n'])",
+                 n: {'.validate': "newData.isNumber()"},
+                 '$other': {'.validate': "false"}} },
+      { data: "type T {s: String}",
+        expect: {'.validate': "newData.hasChildren(['s'])",
+                 s: {'.validate': "newData.isString()"},
+                 '$other': {'.validate': "false"}} },
+      { data: "type T {b: Boolean}",
+        expect: {'.validate': "newData.hasChildren(['b'])",
+                 b: {'.validate': "newData.isBoolean()"},
+                 '$other': {'.validate': "false"}} },
+      { data: "type T {x: Object}",
+        expect: {'.validate': "newData.hasChildren(['x'])",
+                 x: {'.validate': "newData.hasChildren()"},
+                 '$other': {'.validate': "false"}} },
+      { data: "type T {x: Number|String}",
+        expect: {'.validate': "newData.hasChildren(['x'])",
+                 x: {'.validate': "newData.isNumber() || newData.isString()"},
+                 '$other': {'.validate': "false"}} },
+      { data: "type T {a: Number, b: String}",
+        expect: {'.validate': "newData.hasChildren(['a', 'b'])",
+                 a: {'.validate': "newData.isNumber()"},
+                 b: {'.validate': "newData.isString()"},
+                 '$other': {'.validate': "false"}} },
+      { data: "type T {x: Number|Null}",
+        expect: {'.validate': "newData.hasChildren()",
+                 x: {'.validate': "newData.isNumber() || newData.val() == null"},
+                 '$other': {'.validate': "false"}} },
+      { data: "type T {n: Number, validate() {return this.n < 7;}}",
+        expect: {'.validate': "newData.hasChildren(['n']) && newData.child('n').val() < 7",
+                 n: {'.validate': "newData.isNumber()"},
+                 '$other': {'.validate': "false"}} },
+      { data: "type Bigger extends Number {validate() { return this > prior(this); }}" +
+        "type T { ts: Bigger }",
+        expect: {'.validate': "newData.hasChildren(['ts'])",
+                 ts: {'.validate': "newData.isNumber() && newData.val() > data.val()"},
+                 '$other': {'.validate': "false"}} },
+      { data: "type T {a: String, b: String, c: String}",
+        expect: {'.validate': "newData.hasChildren(['a', 'b', 'c'])",
+                 a: {'.validate': "newData.isString()"},
+                 b: {'.validate': "newData.isString()"},
+                 c: {'.validate': "newData.isString()"},
+                 '$other': {'.validate': "false"}} },
+      { data: "type B { foo: Number } type T extends B { bar: String }",
+        expect: {'.validate': "newData.hasChildren(['foo', 'bar'])",
+                 foo: {'.validate': "newData.isNumber()"},
+                 bar: {'.validate': "newData.isString()"},
+                 '$other': {'.validate': "false"}} },
     ];
 
     helper.dataDrivenTest(tests, function(data, expect) {
-      var symbols = parse(data + " path /x is Simple {}");
+      var symbols = parse(data + " path /t is T {}");
       var gen = new bolt.Generator(symbols);
       var rules = gen.generateRules();
       if (expect === undefined) {
-        assert.deepEqual(rules, {"rules": {"x": {} }});
+        assert.deepEqual(rules, {"rules": {}});
       } else {
-        assert.deepEqual(rules, {"rules": {"x": {".validate": expect}}});
+        assert.deepEqual(rules, {"rules": {t: expect}});
       }
+    });
+  });
+
+  suite("extendValidator", function() {
+    var tests = [
+      { data: {target: {}, src: {}},
+        expect: {} },
+      { data: {target: {}, src: {'.x': [1]}},
+        expect: {'.x': [1]} },
+      { data: {target: {'.x': [1]}, src: {'.x': [2]}},
+        expect: {'.x': [1, 2]} },
+      { data: {target: {'.x': [1]}, src: {'.x': [2], c: {'.x': [3]}}},
+        expect: {'.x': [1, 2], c: {'.x': [3]}} },
+      { data: {target: {'.x': [1], c: {'.x': [2]}}, src: {c: {'.x': [3]}}},
+        expect: {'.x': [1], c: {'.x': [2, 3]}} },
+      { data: {target: {}, src: {a: {b: {c: {d: {'.x': [1], e: {'.x': [2]}}}}}}},
+        expect: {a: {b: {c: {d: {'.x': [1], e: {'.x': [2]}}}}}} },
+    ];
+
+    helper.dataDrivenTest(tests, function(data, expect) {
+      generator.extendValidator(data.target, data.src);
+      assert.deepEqual(data.target, expect);
+    });
+  });
+
+  suite("mapValidator", function() {
+    var tests = [
+      { data: {'.x': 1}, expect: {'.x': 2} },
+      { data: {'.x': 2}, expect: {} },
+    ];
+
+    helper.dataDrivenTest(tests, function(data, expect) {
+      generator.mapValidator(data, function(value, prop) {
+        if (value == 2) {
+          return undefined;
+        }
+        return value + 1;
+      });
+      assert.deepEqual(data, expect);
     });
   });
 

--- a/test/mail-test.js
+++ b/test/mail-test.js
@@ -42,7 +42,6 @@ rulesSuite("Mail", function(test) {
       })
       .fails("Sender cannot overwrite.")
 
-    /* NYI
       .at('/users/bill/inbox/2')
       .write({
         from: 'tom',
@@ -51,7 +50,6 @@ rulesSuite("Mail", function(test) {
         spurious: 'supurious data'
       })
       .fails("No undefined fields.")
-    */
 
       .write({
         from: 'george',
@@ -92,7 +90,6 @@ rulesSuite("Mail", function(test) {
 
       .as('bill')
 
-    /* NYI
       .at('/users/bill/outbox/1/message')
       .write("Bill gets my inheritance.")
       .fails("Sender cannot tamper with outbox message.")
@@ -100,7 +97,6 @@ rulesSuite("Mail", function(test) {
       .at('/users/bill/outbox/1/from')
       .write('bill')
       .fails("Can't do a partial overwrite - even if same data.")
-    */
 
       .as('bill')
       .at('/users/bill/outbox/2')
@@ -111,7 +107,6 @@ rulesSuite("Mail", function(test) {
       })
       .fails("From field must be correct.")
 
-    /* NYI
       .write({
         from: 'bill',
         to: 'tom',
@@ -119,7 +114,6 @@ rulesSuite("Mail", function(test) {
         spurious: "spurious"
       })
       .fails("No undefined fields.")
-    */
 
       .at('/users/bill/outbox/1')
       .write(null)

--- a/test/parser-test.js
+++ b/test/parser-test.js
@@ -178,11 +178,11 @@ suite("Rules Parser Tests", function() {
   suite("Paths", function() {
     var tests = [
       { data: "path / {}",
-        expect: {"/": { parts: [], isType: 'Any', methods: {} }} },
+        expect: {"/": { parts: [], isType: ast.typeType('Any'), methods: {} }} },
       { data: "path /x {}",
-        expect: {"/x": { parts: ['x'], isType: 'Any', methods: {} }} },
+        expect: {"/x": { parts: ['x'], isType: ast.typeType('Any'), methods: {} }} },
       { data: "path /p/$q { write() { return true;  }}",
-        expect: {"/p/$q": { isType: 'Any',
+        expect: {"/p/$q": { isType: ast.typeType('Any'),
                             parts: ['p', '$q'],
                             methods: {write: {params: [], body: ast.boolean(true)}}}} }
     ];
@@ -195,30 +195,38 @@ suite("Rules Parser Tests", function() {
   suite("Schema", function() {
     var tests = [
       { data: "type Foo { a: Number }",
-        expect: { derivedFrom: 'Object',
-                  properties: {a: {types: ['Number']}},
+        expect: { derivedFrom: ast.typeType('Object'),
+                  properties: {a: ast.typeType('Number')},
                   methods: {}} },
       { data: "type Foo { a: Number, b: String }",
-        expect: { derivedFrom: 'Object',
-                  properties: {a: {types: ['Number']},
-                               b: {types: ['String']}},
+        expect: { derivedFrom: ast.typeType('Object'),
+                  properties: {a: ast.typeType('Number'),
+                               b: ast.typeType('String')},
                   methods: {}} },
       { data: "type Foo extends Bar {}",
-        expect: { derivedFrom: 'Bar', properties: {}, methods: {}} },
+        expect: { derivedFrom: ast.typeType('Bar'),
+                  properties: {},
+                  methods: {}} },
       { data: "type Foo { a: Number validate() { return true; }}",
-        expect: { derivedFrom: 'Object',
-                  properties: {a: {types: ['Number']}},
+        expect: { derivedFrom: ast.typeType('Object'),
+                  properties: {a: ast.typeType('Number')},
                   methods: {validate: {params: [],
                                        body: ast.boolean(true)}}} },
       { data: "type Foo { a: Number, validate() { return true; }}",
-        expect: { derivedFrom: 'Object',
-                  properties: {a: {types: ['Number']}},
+        expect: { derivedFrom: ast.typeType('Object'),
+                  properties: {a: ast.typeType('Number')},
                   methods: {validate: {params: [],
-                                       body: ast.boolean(true)}}} }
+                                       body: ast.boolean(true)}}} },
+      { data: "type Foo { a: Number | String }",
+        expect: { derivedFrom: ast.typeType('Object'),
+                  properties: {a: ast.unionType([ast.typeType('Number'),
+                                                 ast.typeType('String')])},
+                  methods: {} }},
     ];
 
     helper.dataDrivenTest(tests, function(data, expect) {
-      assert.deepEqual(parse(data).schema.Foo, expect);
+      var result = parse(data).schema.Foo;
+      assert.deepEqual(result, expect);
     });
   });
 
@@ -287,16 +295,12 @@ suite("Rules Parser Tests", function() {
     helper.dataDrivenTest(tests, function(data, expect) {
       var result = parse(data);
       assert.deepEqual(result.schema.T,
-                       { derivedFrom: 'Any', methods: {}, properties: {} });
+                       { derivedFrom: ast.typeType('Any'), methods: {}, properties: {} });
     });
   });
 
   suite("Sample files", function() {
-    var files = [
-      "all_access",
-      "userdoc",
-      "mail"
-    ];
+    var files = ["all_access", "userdoc", "mail", "children", "children-by-nesting"];
 
     helper.dataDrivenTest(files, function(data) {
       var filename = 'test/samples/' + data + '.' + BOLT_EXTENSION;

--- a/test/parser-test.js
+++ b/test/parser-test.js
@@ -300,7 +300,7 @@ suite("Rules Parser Tests", function() {
   });
 
   suite("Sample files", function() {
-    var files = ["all_access", "userdoc", "mail", "children", "children-by-nesting"];
+    var files = ["all_access", "userdoc", "mail", "children"];
 
     helper.dataDrivenTest(files, function(data) {
       var filename = 'test/samples/' + data + '.' + BOLT_EXTENSION;

--- a/test/samples/children-by-nesting.bolt
+++ b/test/samples/children-by-nesting.bolt
@@ -1,0 +1,9 @@
+type Child {
+  age: Number
+}
+
+type Parent {
+  children: Child[]
+}
+
+path /parents is Parent[] {}

--- a/test/samples/children-by-nesting.json
+++ b/test/samples/children-by-nesting.json
@@ -1,0 +1,11 @@
+{
+  "rules": {
+    "parents": {
+      "$parent": {
+        "$child": {
+          ".validate": "newData.child('age').isNumber()"
+        }
+      }
+    }
+  }
+}

--- a/test/samples/children.bolt
+++ b/test/samples/children.bolt
@@ -1,0 +1,9 @@
+type Child {
+  age: Number
+}
+
+type Parent {
+}
+
+path /parents/$parent        is Parent {}
+path /parents/$parent/$child is Child {}

--- a/test/samples/children.json
+++ b/test/samples/children.json
@@ -1,0 +1,17 @@
+{
+  "rules": {
+    "parents": {
+      "$parent": {
+        "$child": {
+          ".validate": "newData.hasChildren(['age'])",
+          "age": {
+            ".validate": "newData.isNumber()"
+          },
+          "$other": {
+            ".validate": "false"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/samples/mail.bolt
+++ b/test/samples/mail.bolt
@@ -1,48 +1,46 @@
-// Functionally similar rules to
+// Mail.bolt - Inbox and Outbox Rules.
+//
+// These rules support putting Messages in an Inbox (for another user)
+// and making a record of all email sent in an outbox.
+//
+// Design goals:
+//
+// - Anyone can send a message to anybody by posting in the users inbox, as long as they have
+//   the correct from field.
+// - Cannot forge the from field of a message.
+// - Cannot alter a message once created (it can only be deleted in-toto).
+//
+// Functionally similar rules to the corresponding rules defined in the Blaze Compiler:
 // https://github.com/firebase/blaze_compiler/blob/master/examples/mail_example.yaml
 
+type ImmutableString extends String {
+  validate() = isNew(this);
+}
+
 type Message {
-  from: String
-  to: String
-  message: String
+  from: ImmutableString,
+  to: ImmutableString,
+  message: ImmutableString,
 
   validate() {
     return isCurrentUser(this.from);
   }
-
-  // extensible(prop) { return false; }
 }
 
-// The inbox is someone's incoming mail.
+// Inbox
 path /users/$userid/inbox/$msg is Message {
-  // Users can read their own inbox
-  read() { return isCurrentUser($userid); }
-
-  // Anyone can send a message to anybody by posting in the users inbox, as long as they have
-  // the correct sender field.
-  write() {
-    return isCreating(this) ||
-      isUpdating(this) && isCurrentUser($userid);
-  }
-
+  read() = isCurrentUser($userid);
+  write() = isNew(this) || isCurrentUser($userid);
 }
 
-// The outbox is for recording what has been sent by a user.
+// Outbox
 path /users/$userid/outbox/$msg is Message {
-  read() { return isCurrentUser($userid); }
-
-  write() {
-    return isCreating(this) ||
-      isUpdating(this) && isCurrentUser($userid);
-  }
+  read() = isCurrentUser($userid);
+  write() = isCurrentUser($userid);
 }
 
-function isCreating(old) {
-  return prior(old) == null;
-}
-
-function isUpdating(old) {
-  return prior(old) != null;
+function isNew(ref) {
+  return prior(ref) == null;
 }
 
 function isCurrentUser(userid) {
@@ -50,5 +48,6 @@ function isCurrentUser(userid) {
 }
 
 function currentUser() {
+  // TODO: Use auth.uid - so not require customer token.
   return auth.username;
 }

--- a/test/samples/mail.bolt
+++ b/test/samples/mail.bolt
@@ -13,17 +13,13 @@
 // Functionally similar rules to the corresponding rules defined in the Blaze Compiler:
 // https://github.com/firebase/blaze_compiler/blob/master/examples/mail_example.yaml
 
-type ImmutableString extends String {
-  validate() = isNew(this);
-}
-
 type Message {
-  from: ImmutableString,
-  to: ImmutableString,
-  message: ImmutableString,
+  from: String,
+  to: String,
+  message: String,
 
   validate() {
-    return isCurrentUser(this.from);
+    return isNew(this) && isCurrentUser(this.from);
   }
 }
 
@@ -39,15 +35,9 @@ path /users/$userid/outbox/$msg is Message {
   write() = isCurrentUser($userid);
 }
 
-function isNew(ref) {
-  return prior(ref) == null;
-}
+isNew(ref) = prior(ref) == null;
 
-function isCurrentUser(userid) {
-  return currentUser() == userid;
-}
+isCurrentUser(userid) = currentUser() == userid;
 
-function currentUser() {
-  // TODO: Use auth.uid - so not require customer token.
-  return auth.username;
-}
+// TODO: Use auth.uid - so not require customer token.
+currentUser() = auth.username;

--- a/test/samples/mail.json
+++ b/test/samples/mail.json
@@ -4,16 +4,40 @@
       "$userid": {
         "inbox": {
           "$msg": {
+            ".validate": "newData.hasChildren(['from', 'to', 'message']) && auth.username == newData.child('from').val()",
+            "from": {
+              ".validate": "newData.isString()"
+            },
+            "to": {
+              ".validate": "newData.isString()"
+            },
+            "message": {
+              ".validate": "newData.isString()"
+            },
+            "$other": {
+              ".validate": "false"
+            },
             ".read": "auth.username == $userid",
-            ".write": "data.val() == null || data.val() != null && auth.username == $userid",
-            ".validate": "newData.child('from').isString() && newData.child('to').isString() && newData.child('message').isString() && auth.username == newData.child('from').val()"
+            ".write": "data.val() == null || data.val() != null && auth.username == $userid"
           }
         },
         "outbox": {
           "$msg": {
+            ".validate": "newData.hasChildren(['from', 'to', 'message']) && auth.username == newData.child('from').val()",
+            "from": {
+              ".validate": "newData.isString()"
+            },
+            "to": {
+              ".validate": "newData.isString()"
+            },
+            "message": {
+              ".validate": "newData.isString()"
+            },
+            "$other": {
+              ".validate": "false"
+            },
             ".read": "auth.username == $userid",
-            ".write": "data.val() == null || data.val() != null && auth.username == $userid",
-            ".validate": "newData.child('from').isString() && newData.child('to').isString() && newData.child('message').isString() && auth.username == newData.child('from').val()"
+            ".write": "data.val() == null || data.val() != null && auth.username == $userid"
           }
         }
       }

--- a/test/samples/mail.json
+++ b/test/samples/mail.json
@@ -4,15 +4,15 @@
       "$userid": {
         "inbox": {
           "$msg": {
-            ".validate": "newData.hasChildren(['from', 'to', 'message']) && auth.username == newData.child('from').val()",
+            ".validate": "newData.hasChildren(['from', 'to', 'message']) && (data.val() == null && auth.username == newData.child('from').val())",
             "from": {
-              ".validate": "newData.isString() && data.val() == null"
+              ".validate": "newData.isString()"
             },
             "to": {
-              ".validate": "newData.isString() && data.val() == null"
+              ".validate": "newData.isString()"
             },
             "message": {
-              ".validate": "newData.isString() && data.val() == null"
+              ".validate": "newData.isString()"
             },
             "$other": {
               ".validate": "false"
@@ -23,15 +23,15 @@
         },
         "outbox": {
           "$msg": {
-            ".validate": "newData.hasChildren(['from', 'to', 'message']) && auth.username == newData.child('from').val()",
+            ".validate": "newData.hasChildren(['from', 'to', 'message']) && (data.val() == null && auth.username == newData.child('from').val())",
             "from": {
-              ".validate": "newData.isString() && data.val() == null"
+              ".validate": "newData.isString()"
             },
             "to": {
-              ".validate": "newData.isString() && data.val() == null"
+              ".validate": "newData.isString()"
             },
             "message": {
-              ".validate": "newData.isString() && data.val() == null"
+              ".validate": "newData.isString()"
             },
             "$other": {
               ".validate": "false"

--- a/test/samples/mail.json
+++ b/test/samples/mail.json
@@ -6,38 +6,38 @@
           "$msg": {
             ".validate": "newData.hasChildren(['from', 'to', 'message']) && auth.username == newData.child('from').val()",
             "from": {
-              ".validate": "newData.isString()"
+              ".validate": "newData.isString() && data.val() == null"
             },
             "to": {
-              ".validate": "newData.isString()"
+              ".validate": "newData.isString() && data.val() == null"
             },
             "message": {
-              ".validate": "newData.isString()"
+              ".validate": "newData.isString() && data.val() == null"
             },
             "$other": {
               ".validate": "false"
             },
             ".read": "auth.username == $userid",
-            ".write": "data.val() == null || data.val() != null && auth.username == $userid"
+            ".write": "data.val() == null || auth.username == $userid"
           }
         },
         "outbox": {
           "$msg": {
             ".validate": "newData.hasChildren(['from', 'to', 'message']) && auth.username == newData.child('from').val()",
             "from": {
-              ".validate": "newData.isString()"
+              ".validate": "newData.isString() && data.val() == null"
             },
             "to": {
-              ".validate": "newData.isString()"
+              ".validate": "newData.isString() && data.val() == null"
             },
             "message": {
-              ".validate": "newData.isString()"
+              ".validate": "newData.isString() && data.val() == null"
             },
             "$other": {
               ".validate": "false"
             },
             ".read": "auth.username == $userid",
-            ".write": "data.val() == null || data.val() != null && auth.username == $userid"
+            ".write": "auth.username == $userid"
           }
         }
       }

--- a/test/samples/type-extension.json
+++ b/test/samples/type-extension.json
@@ -1,5 +1,17 @@
 {
   "rules": {
-    ".validate": "newData.child('time').isNumber() && newData.child('time').val() >= 0 && (newData.child('name').isString() && newData.child('name').val().length > 0) && (newData.child('url').isString() && newData.child('url').val().beginsWith('http'))"
+    ".validate": "newData.hasChildren(['time', 'name', 'url'])",
+    "time": {
+      ".validate": "newData.isNumber() && newData.val() >= 0"
+    },
+    "name": {
+      ".validate": "newData.isString() && newData.val().length > 0"
+    },
+    "url": {
+      ".validate": "newData.isString() && newData.val().beginsWith('http')"
+    },
+    "$other": {
+      ".validate": "false"
+    }
   }
 }

--- a/test/samples/user-security.bolt
+++ b/test/samples/user-security.bolt
@@ -1,0 +1,59 @@
+// user-security.bolt - Chat room example.
+//
+// Design goals:
+//
+// - Any logged in user can get a list of room names.
+// - Room names are read-only
+// - Users can only add/remove themselves to rooms.
+// - Users can go by a different nickname in each room.
+// - Messages can be read by any room member.
+// - Messages can be created by any member.
+// - Messages cannot be modified or deleted.
+// - Messages are signed by user's uid, and timestamped.
+//
+// See https://www.firebase.com/docs/security/guide/user-security.html
+
+path /room_names { read() = auth != null; }
+path /room_names/$room_id is String;
+
+type Nickname extends String {
+  validate() = this.length > 0 && this.length < 20;
+}
+
+type UserID extends String {
+  validate() = isCurrentUser(this);
+}
+
+path /members/$room_id {
+  read() = this[auth.uid] != null;
+}
+
+path /members/$room_id/$user_id is Nickname {
+  write() = isCurrentUser($user_id);
+}
+
+type MessageString extends String {
+  validate() = this.length > 0 && this.length < 50;
+}
+
+type Timestamp extends Number { validate() = this <= now; }
+
+type Message {
+  validate() = isNew(this);
+
+  user: UserID,
+  message: MessageString,
+  timestamp: Timestamp
+}
+
+path /messages/$room_id {
+  read() = root.room_names[$room_id] != null;
+}
+
+path /messages/$room_id/$message_id is Message {
+  write() = root.members[$room_id][auth.uid] != null;
+}
+
+isCurrentUser(id) = auth != null && auth.uid == id;
+
+isNew(ref) = prior(this) == null;

--- a/test/samples/user-security.json
+++ b/test/samples/user-security.json
@@ -1,0 +1,40 @@
+{
+  "rules": {
+    "room_names": {
+      ".read": "auth != null",
+      "$room_id": {
+        ".validate": "newData.isString()"
+      }
+    },
+    "members": {
+      "$room_id": {
+        ".read": "data.child(auth.uid).val() != null",
+        "$user_id": {
+          ".validate": "newData.isString() && (newData.val().length > 0 && newData.val().length < 20)",
+          ".write": "auth != null && auth.uid == $user_id"
+        }
+      }
+    },
+    "messages": {
+      "$room_id": {
+        ".read": "root.child('room_names').child($room_id).val() != null",
+        "$message_id": {
+          ".validate": "newData.hasChildren(['user', 'message', 'timestamp']) && this == null",
+          "user": {
+            ".validate": "newData.isString() && (auth != null && auth.uid == newData.val())"
+          },
+          "message": {
+            ".validate": "newData.isString() && (newData.val().length > 0 && newData.val().length < 50)"
+          },
+          "timestamp": {
+            ".validate": "newData.isNumber() && newData.val() <= now"
+          },
+          "$other": {
+            ".validate": "false"
+          },
+          ".write": "root.child('members').child($room_id).child(auth.uid).val() != null"
+        }
+      }
+    }
+  }
+}

--- a/test/samples/userdoc.json
+++ b/test/samples/userdoc.json
@@ -16,7 +16,19 @@
         ".read": "auth.uid == $ownerid",
         ".write": "auth.uid == $ownerid",
         "$docid": {
-          ".validate": "newData.child('created').isString() && newData.child('modified').isString() && newData.child('title').isString()",
+          ".validate": "newData.hasChildren(['created', 'modified', 'title'])",
+          "created": {
+            ".validate": "newData.isString()"
+          },
+          "modified": {
+            ".validate": "newData.isString()"
+          },
+          "title": {
+            ".validate": "newData.isString()"
+          },
+          "$other": {
+            ".validate": "false"
+          },
           ".read": "root.child('permissions').child(auth.uid + '|' + $ownerid + '|' + $docid).child('read').val() == true",
           ".write": "root.child('permissions').child(auth.uid + '|' + $ownerid + '|' + $docid).child('write').val() == true"
         }
@@ -30,7 +42,19 @@
         "docid"
       ],
       "$key": {
-        ".validate": "newData.child('owner').isString() && newData.child('grantee').isString() && newData.child('docid').isString()",
+        ".validate": "newData.hasChildren(['owner', 'grantee', 'docid'])",
+        "owner": {
+          ".validate": "newData.isString()"
+        },
+        "grantee": {
+          ".validate": "newData.isString()"
+        },
+        "docid": {
+          ".validate": "newData.isString()"
+        },
+        "$other": {
+          ".validate": "false"
+        },
         ".write": "newData.val() == null && auth.uid == data.child('owner').val() || newData.val() != null && $key == newData.child('grantee').val() + '|' + newData.child('owner').val() + '|' + newData.child('docid').val() && auth.uid == newData.child('owner').val() && root.child('documents').child(auth.uid).child(newData.child('docid').val()).val() != null"
       }
     }

--- a/test/util-test.js
+++ b/test/util-test.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"use strict";
+
+var assert = require('chai').assert;
+var helper = require('./test-helper');
+
+var util = require('../lib/util');
+
+suite("Util", function() {
+  suite("pruneEmptyChildren", function() {
+    function T() {
+    }
+
+    var tests = [
+      [ {}, {} ],
+      [ {a: 1}, {a: 1} ],
+      [ {a: {}}, {} ],
+      [ {a: 1, b: {}}, {a: 1} ],
+      [ {a: []}, {a: []} ],
+      [ {a: new T()}, {a: new T()} ],
+      [ {a: {a: {a: {}}}}, {} ],
+      [ {a: {a: {a: {}, b: 1}}}, {a: {a: {b: 1}}} ],
+    ];
+
+    helper.dataDrivenTest(tests, function(data, expect) {
+      util.pruneEmptyChildren(data);
+      assert.deepEqual(data, expect);
+    });
+  });
+});


### PR DESCRIPTION
Instead of merging all validation sub-expressions into one top-level expression, we now compute a "validator" - a tree of expression fragments that are AND-ed together when the final expressions are built.

This allows us to add a "wild-child" property with validate == false to prevent adding additional properties, as well as better merge disparate validation expressions.

We also make "type" a first-class AST value in preparation for allowing generic types (Map<String, Any>) for $key-validation expressions in derived versions of String.