### PR TITLE
Simulation no longer relies on custom token - use auth.uid.

### DIFF
--- a/lib/firebase-rest.js
+++ b/lib/firebase-rest.js
@@ -20,19 +20,23 @@ var Promise = require('promise');
 var https = require('https');
 var util = require('./util');
 var querystring = require('querystring');
+var uuid = require('node-uuid');
+var FirebaseTokenGenerator = require('firebase-token-generator');
 
 var FIREBASE_HOST = 'firebaseio.com';
 
 module.exports = {
   "Client": Client,
+  "generateUidAuthToken": generateUidAuthToken,
 
   RULES_LOCATION: '/.settings/rules',
   TIMESTAMP: {".sv": "timestamp"},
 };
 
-function Client(appName, authToken) {
+function Client(appName, authToken, uid) {
   this.appName = appName;
   this.authToken = authToken;
+  this.uid = uid;
 }
 
 util.methods(Client, {
@@ -127,4 +131,14 @@ function request(options, content, debug) {
       reject(error);
     });
   });
+}
+
+// opts { debug: Boolean, admin: Boolean }
+function generateUidAuthToken(secret, opts) {
+  opts = util.extend({ debug: false, admin: false }, opts);
+
+  var tokenGenerator = new FirebaseTokenGenerator(secret);
+  var uid = uuid.v4();
+  var token = tokenGenerator.createToken({ uid: uid }, opts);
+  return { uid: uid, token: token };
 }

--- a/lib/simulator.js
+++ b/lib/simulator.js
@@ -18,10 +18,8 @@
 "use strict";
 
 var Promise = require('promise');
-var uuid = require('node-uuid');
 var assert = require('chai').assert;
 var rest = require('./firebase-rest');
-var FirebaseTokenGenerator = require('firebase-token-generator');
 
 // Browserify bug: https://github.com/substack/node-browserify/issues/1150
 var bolt = (typeof window != 'undefined' && window.bolt) || require('./bolt');
@@ -95,11 +93,13 @@ util.methods(RulesSuite, {
   // Interface for test functions:
   //   test.rules(rulesPath)
   //   test.database(appName, appSecret)
+  //   test.uid(username)
   //   test(testName, testFunction)
   getInterface: function() {
     var test = this.test.bind(this);
     test.rules = this.rules.bind(this);
     test.database = this.database.bind(this);
+    test.uid = this.uid.bind(this);
     return test;
   },
 
@@ -144,26 +144,27 @@ util.methods(RulesSuite, {
     }
     this.appName = appName;
     this.appSecret = appSecret;
-    // Why won't this work for writing rules?
-    // this.adminClient = this.ensureUser('admin');
-    this.adminClient = new rest.Client(appName, appSecret);
-    this.anonClient = new rest.Client(appName);
+    this.adminClient = this.ensureUser('admin');
     this.databaseReady();
   },
 
+  uid: function(username) {
+    return this.ensureUser(username).uid;
+  },
+
   ensureUser: function(username) {
-    if (username == 'admin') {
-      return this.adminClient;
-    }
-    if (username == 'anon') {
-      return this.anonClient;
+    if (!(username in this.users)) {
+      if (username == 'anon') {
+        this.users[username] = new rest.Client(this.appName);
+      } else {
+        var tokenInfo;
+        tokenInfo = rest.generateUidAuthToken(this.appSecret,
+                                              { debug: true,
+                                                admin: username == 'admin' });
+        this.users[username] = new rest.Client(this.appName, tokenInfo.token, tokenInfo.uid);
+      }
     }
 
-    if (!(username in this.users)) {
-      // TODO: How is this working taking a non-allowed option???
-      var token = generateAuthToken({ username: username }, this.appSecret);
-      this.users[username] = new rest.Client(this.appName, token);
-    }
     return this.users[username];
   },
 });
@@ -322,14 +323,3 @@ util.methods(RulesTest, {
     return this.suite.suiteName + "." + this.testName + " " + message;
   }
 });
-
-function generateAuthToken(opts, secret) {
-  opts = util.extend({
-    uid: uuid.v4(),
-    debug: true,
-  }, opts);
-
-  var tokenGenerator = new FirebaseTokenGenerator(secret);
-  var token = tokenGenerator.createToken(opts);
-  return token;
-}

--- a/test/mail-test.js
+++ b/test/mail-test.js
@@ -18,16 +18,18 @@ var rulesSuite = bolt.rulesSuite;
 var secrets = require('./auth-secrets');
 
 rulesSuite("Mail", function(test) {
+  var uid = test.uid;
+
   test.database(secrets.APP, secrets.SECRET);
   test.rules('test/samples/mail');
 
   test("Inbox tests.", function(rules) {
     rules
       .as('tom')
-      .at('/users/bill/inbox/1')
+      .at('/users/' + uid('bill') + '/inbox/1')
       .write({
-        from: 'tom',
-        to: 'bill',
+        from: uid('tom'),
+        to: uid('bill'),
         message: 'Hi, Bill!'
       })
       .succeeds("Normal write.")
@@ -36,38 +38,38 @@ rulesSuite("Mail", function(test) {
       .fails("Sender cannot delete sent message.")
 
       .write({
-        from: 'tom',
-        to: 'bill',
+        from: uid('tom'),
+        to: uid('bill'),
         message: 'Hello, again!'
       })
       .fails("Sender cannot overwrite.")
 
-      .at('/users/bill/inbox/2')
+      .at('/users/' + uid('bill') + '/inbox/2')
       .write({
-        from: 'tom',
-        to: 'bill',
+        from: uid('tom'),
+        to: uid('bill'),
         message: 'Hi, Bill!',
         spurious: 'supurious data'
       })
       .fails("No undefined fields.")
 
       .write({
-        from: 'george',
-        to: 'bill',
+        from: uid('george'),
+        to: uid('bill'),
         message: 'Hi, Bill!'
       })
       .fails("From field should be correct.")
 
-      .at('/users/bill/inbox/1/message')
+      .at('/users/' + uid('bill') + '/inbox/1/message')
       .write("Bill gets my inheritance")
       .fails("Cannnot tamper with message.")
 
-      .at('/users/bill/inbox/1/from')
-      .write('bill')
+      .at('/users/' + uid('bill') + '/inbox/1/from')
+      .write(uid('bill'))
       .fails("Cannot tamper with from field.")
 
       .as('bill')
-      .at('/users/bill/inbox/1')
+      .at('/users/' + uid('bill') + '/inbox/1')
       .write(null)
       .succeeds("Receiver can delete received mail.");
   });
@@ -76,10 +78,10 @@ rulesSuite("Mail", function(test) {
   test("Outbox tests.", function(rules) {
     rules
       .as('bill')
-      .at('/users/bill/outbox/1')
+      .at('/users/' + uid('bill') + '/outbox/1')
       .write({
-        from: 'bill',
-        to: 'tom',
+        from: uid('bill'),
+        to: uid('tom'),
         message: "Hi, Tom!"
       })
       .succeeds("Normal write.")
@@ -90,16 +92,16 @@ rulesSuite("Mail", function(test) {
 
       .as('bill')
 
-      .at('/users/bill/outbox/1/message')
+      .at('/users/' + uid('bill') + '/outbox/1/message')
       .write("Bill gets my inheritance.")
       .fails("Sender cannot tamper with outbox message.")
 
-      .at('/users/bill/outbox/1/from')
+      .at('/users/' + uid('bill') + '/outbox/1/from')
       .write('bill')
       .fails("Can't do a partial overwrite - even if same data.")
 
       .as('bill')
-      .at('/users/bill/outbox/2')
+      .at('/users/' + uid('bill') + '/outbox/2')
       .write({
         from: 'joe',
         to: 'tom',
@@ -115,7 +117,7 @@ rulesSuite("Mail", function(test) {
       })
       .fails("No undefined fields.")
 
-      .at('/users/bill/outbox/1')
+      .at('/users/' + uid('bill') + '/outbox/1')
       .write(null)
       .succeeds("Sender can delete sent mail in outbox.");
   });
@@ -123,37 +125,37 @@ rulesSuite("Mail", function(test) {
   test("Read permissions.", function(rules) {
     rules
       .as('bill')
-      .at('/users/bill/outbox/1')
+      .at('/users/' + uid('bill') + '/outbox/1')
       .write({
-        from: 'bill',
-        to: 'tom',
+        from: uid('bill'),
+        to: uid('tom'),
         message: 'Hi, Tom!'
       })
       .succeeds("Normal write.")
 
       .as('tom')
-      .at('/users/bill/inbox/1')
+      .at('/users/' + uid('bill') + '/inbox/1')
       .write({
-        from: 'tom',
-        to: 'bill',
+        from: uid('tom'),
+        to: uid('bill'),
         message: 'Hi, Bill!'
       })
 
       .as('bill')
-      .at('/users/bill/inbox/1')
+      .at('/users/' + uid('bill') + '/inbox/1')
       .read()
       .succeeds("Can read own inbox.")
 
-      .at('/users/bill/outbox/1')
+      .at('/users/' + uid('bill') + '/outbox/1')
       .read()
       .succeeds("Can read own outbox.")
 
       .as('tom')
-      .at('/users/bill/inbox/1')
+      .at('/users/' + uid('bill') + '/inbox/1')
       .read()
       .fails("Can't read Bill's inbox.")
 
-      .at('/users/bill/outbox/1')
+      .at('/users/' + uid('bill') + '/outbox/1')
       .read()
       .fails("Can't read Bills outbox.");
   });

--- a/test/samples/mail.bolt
+++ b/test/samples/mail.bolt
@@ -37,7 +37,4 @@ path /users/$userid/outbox/$msg is Message {
 
 isNew(ref) = prior(ref) == null;
 
-isCurrentUser(userid) = currentUser() == userid;
-
-// TODO: Use auth.uid - so not require customer token.
-currentUser() = auth.username;
+isCurrentUser(userid) = auth != null && auth.uid == userid;

--- a/test/samples/mail.json
+++ b/test/samples/mail.json
@@ -4,7 +4,7 @@
       "$userid": {
         "inbox": {
           "$msg": {
-            ".validate": "newData.hasChildren(['from', 'to', 'message']) && (data.val() == null && auth.username == newData.child('from').val())",
+            ".validate": "newData.hasChildren(['from', 'to', 'message']) && (data.val() == null && (auth != null && auth.uid == newData.child('from').val()))",
             "from": {
               ".validate": "newData.isString()"
             },
@@ -17,13 +17,13 @@
             "$other": {
               ".validate": "false"
             },
-            ".read": "auth.username == $userid",
-            ".write": "data.val() == null || auth.username == $userid"
+            ".read": "auth != null && auth.uid == $userid",
+            ".write": "data.val() == null || auth != null && auth.uid == $userid"
           }
         },
         "outbox": {
           "$msg": {
-            ".validate": "newData.hasChildren(['from', 'to', 'message']) && (data.val() == null && auth.username == newData.child('from').val())",
+            ".validate": "newData.hasChildren(['from', 'to', 'message']) && (data.val() == null && (auth != null && auth.uid == newData.child('from').val()))",
             "from": {
               ".validate": "newData.isString()"
             },
@@ -36,8 +36,8 @@
             "$other": {
               ".validate": "false"
             },
-            ".read": "auth.username == $userid",
-            ".write": "auth.username == $userid"
+            ".read": "auth != null && auth.uid == $userid",
+            ".write": "auth != null && auth.uid == $userid"
           }
         }
       }


### PR DESCRIPTION
FYI @tomlarkworthy 

Simulation and mail test is more generally applicable if we don't rely on fields in a custom auth token.