### PR TITLE
Remove excess parens generated from andArray processing.

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -69,6 +69,7 @@ module.exports = {
 
   'andArray': leftAssociateGen('&&', boolean(true), boolean(false)),
   'orArray': leftAssociateGen('||', boolean(false), boolean(true)),
+  'flatten': flatten,
 
   // Type operators
   'typeType': typeType,
@@ -182,6 +183,14 @@ function valueGen(typeName) {
   };
 }
 
+function cmpValues(v1, v2) {
+  return v1.typeName == v2.typeName && v1.value == v2.value;
+}
+
+function isOp(opType, exp) {
+  return exp.type == 'op' && exp.op == opType;
+}
+
 // Return a generating function to make an operator exp node.
 function opGen(opType, arity) {
   if (arity === undefined) {
@@ -196,10 +205,21 @@ function opGen(opType, arity) {
   };
 }
 
-// A reducing function for binary operators - use with [].reduce
-// initialValue's in array are ignored (or returned for empty array).
-function leftAssociateGen(opType, initialValue, shortcutValue) {
+// Create an expression builder function which operates on arrays of values.
+// Returns new expression like v1 op v2 op v3 ...
+//
+// - Any identityValue's in array input are ignored.
+// - If zeroValue is found - just return zeroValue.
+//
+// Our function re-orders top-level op in array elements to the resulting
+// expression is left-associating.  E.g.:
+//
+//    [a && b, c && d] => (((a && b) && c) && d)
+//    (NOT (a && b) && (c && d))
+function leftAssociateGen(opType, identityValue, zeroValue) {
   return function(a) {
+    var i;
+
     function reducer(result, current) {
       if (result === undefined) {
         return current;
@@ -207,23 +227,52 @@ function leftAssociateGen(opType, initialValue, shortcutValue) {
       return op(opType, [result, current]);
     }
 
+    // First flatten all top-level op values to one flat array.
+    var flat = [];
+    for (i = 0; i < a.length; i++) {
+      flatten(opType, a[i], flat);
+    }
+
     var result = [];
-    for (var i = 0; i < a.length; i++) {
-      if (a[i].type == initialValue.type && a[i].value == initialValue.value) {
+    for (i = 0; i < flat.length; i++) {
+      // Remove identifyValues from array.
+      if (cmpValues(flat[i], identityValue)) {
         continue;
       }
-      if (a[i].type == shortcutValue.type && a[i].value == shortcutValue.value) {
-        return shortcutValue;
+      // Just return zeroValue if found
+      if (cmpValues(flat[i], zeroValue)) {
+        return zeroValue;
       }
-      result.push(a[i]);
+      result.push(flat[i]);
     }
 
     if (result.length == 0) {
-      return initialValue;
+      return identityValue;
     }
 
+    // Return left-associative expression of opType.
     return result.reduce(reducer);
   };
+}
+
+// Flatten the top level tree of op into a single flat array of expressions.
+function flatten(opType, exp, flat) {
+  var i;
+
+  if (flat === undefined) {
+    flat = [];
+  }
+
+  if (!isOp(opType, exp)) {
+    flat.push(exp);
+    return flat;
+  }
+
+  for (i = 0; i < exp.args.length; i++) {
+    flatten(opType, exp.args[i], flat);
+  }
+
+  return flat;
 }
 
 function op(opType, args) {

--- a/test/samples/mail.json
+++ b/test/samples/mail.json
@@ -4,7 +4,7 @@
       "$userid": {
         "inbox": {
           "$msg": {
-            ".validate": "newData.hasChildren(['from', 'to', 'message']) && (data.val() == null && (auth != null && auth.uid == newData.child('from').val()))",
+            ".validate": "newData.hasChildren(['from', 'to', 'message']) && data.val() == null && (auth != null && auth.uid == newData.child('from').val())",
             "from": {
               ".validate": "newData.isString()"
             },
@@ -23,7 +23,7 @@
         },
         "outbox": {
           "$msg": {
-            ".validate": "newData.hasChildren(['from', 'to', 'message']) && (data.val() == null && (auth != null && auth.uid == newData.child('from').val()))",
+            ".validate": "newData.hasChildren(['from', 'to', 'message']) && data.val() == null && (auth != null && auth.uid == newData.child('from').val())",
             "from": {
               ".validate": "newData.isString()"
             },

--- a/test/samples/user-security.json
+++ b/test/samples/user-security.json
@@ -10,7 +10,7 @@
       "$room_id": {
         ".read": "data.child(auth.uid).val() != null",
         "$user_id": {
-          ".validate": "newData.isString() && (newData.val().length > 0 && newData.val().length < 20)",
+          ".validate": "newData.isString() && newData.val().length > 0 && newData.val().length < 20",
           ".write": "auth != null && auth.uid == $user_id"
         }
       }
@@ -24,7 +24,7 @@
             ".validate": "newData.isString() && (auth != null && auth.uid == newData.val())"
           },
           "message": {
-            ".validate": "newData.isString() && (newData.val().length > 0 && newData.val().length < 50)"
+            ".validate": "newData.isString() && newData.val().length > 0 && newData.val().length < 50"
           },
           "timestamp": {
             ".validate": "newData.isNumber() && newData.val() <= now"

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -16,9 +16,11 @@
 "use strict";
 
 var util = require('../lib/util');
+var gen = require('../lib/rules-generator');
 
 module.exports = {
-  'dataDrivenTest': dataDrivenTest
+  'dataDrivenTest': dataDrivenTest,
+  'expFormat': expFormat,
 };
 
 /*
@@ -76,4 +78,24 @@ function format(o) {
   default:
     return JSON.stringify(o);
   }
+}
+
+function expFormat(x) {
+  if (util.isType(x, 'array')) {
+    return '[' + x.map(expFormat).join(', ') + ']';
+  }
+  if (util.isType(x, 'object')) {
+    if ('type' in x) {
+      return gen.decodeExpression(x);
+    }
+    var result = '{';
+    var sep = '';
+    for (var prop in x) {
+      result += sep + expFormat(x[prop]);
+      sep = ', ';
+    }
+    result += '}';
+    return result;
+  }
+  return JSON.stringify(x);
 }


### PR DESCRIPTION
@tomlarkworthy FYI

We were preserving right-associating && across calls to andArray - that was not the intention (and it added extra levels of parens).  This PR adds a "flattening" step so that any sub-expressions that are top level && terms and flattened out before re-combining again in a (left-associative) && expression.