### PR TITLE
Type annotations for rules-generator.ts.

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -140,6 +140,16 @@ export function reference(base: Exp, prop: string | Exp): ExpReference {
   };
 }
 
+// Shallow copy of an expression (so it can be modified and preserve
+// immutability of the original expression).
+export function copyExp(exp: Exp): Exp {
+  exp = <Exp> util.extend({}, exp);
+  if (exp.type === 'op' || exp.type === 'call') {
+    (<ExpOp> exp).args = util.copyArray((<ExpOp> exp).args);
+  }
+  return exp;
+}
+
 // Make a (shallow) copy of the base expression, setting (or removing) it's
 // valueType.
 //
@@ -147,7 +157,7 @@ export function reference(base: Exp, prop: string | Exp): ExpReference {
 // 'Snapshot') - used to know when type coercion is needed in the context
 // of parent expressions.
 export function cast(base: Exp, valueType: string): Exp {
-  var result = util.extend({}, base);
+  var result = copyExp(base);
   result.valueType = valueType;
   return result;
 }

--- a/src/test/generator-test.ts
+++ b/src/test/generator-test.ts
@@ -362,16 +362,16 @@ suite("Rules Generator Tests", function() {
 
   suite("mapValidator", function() {
     var tests = [
-      { data: {'.x': 1}, expect: {'.x': 2} },
-      { data: {'.x': 2}, expect: {} },
+      { data: {'.x': 'a'}, expect: {'.x': 'a+'} },
+      { data: {'.x': 'b'}, expect: {} },
     ];
 
     helper.dataDrivenTest(tests, function(data, expect) {
       generator.mapValidator(data, function(value, prop) {
-        if (value === 2) {
+        if (value === 'b') {
           return undefined;
         }
-        return value + 1;
+        return value + '+';
       });
       assert.deepEqual(data, expect);
     });

--- a/tools/run-tests
+++ b/tools/run-tests
@@ -4,5 +4,5 @@
 set -e
 
 cd $PROJ_DIR
-gulp lint
+gulp lint build
 mocha lib/test --ui tdd "$@"

--- a/tslint.json
+++ b/tslint.json
@@ -30,7 +30,7 @@
     "no-empty": true,
     "no-eval": true,
     "no-shadowed-variable": true,
-    "no-string-literal": true,
+    "no-string-literal": false,
     "no-switch-case-fall-through": true,
     "no-trailing-comma": false,
     "no-trailing-whitespace": true,


### PR DESCRIPTION
Added type annotations to all exported symbols of rules-generator.

- Removed the unused methods for push/pop globals.
- Simplify the copy semantics of partialEval - less efficient but simpler code (retain immutability).

@tomlarkworthy 