### PR TITLE
Allow read and write methods in types.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -125,6 +125,10 @@ gulp.task('browserify-mail-test', function() {
   return browserifyToDist('lib/test/mail-test', { exclude: 'bolt' });
 });
 
+gulp.task('browserify-chat-test', function() {
+  return browserifyToDist('lib/test/chat-test', { exclude: 'bolt' });
+});
+
 gulp.task('browserify-ast-test', function() {
   return browserifyToDist('lib/test/ast-test.js', { exclude: 'bolt' });
 });
@@ -137,6 +141,7 @@ gulp.task('browserify', ['browserify-bolt',
                          'browserify-parser-test',
                          'browserify-generator-test',
                          'browserify-mail-test',
+                         'browserify-chat-test',
                          'browserify-util-test',
                          'browserify-ast-test',
                         ]);

--- a/samples/chat.bolt
+++ b/samples/chat.bolt
@@ -13,7 +13,7 @@ type Room {
 
   // The creator of a room can delete (or create) any part of a room
   // including members and posts.
-  write() = createOnly(this) || isUser(this.creator);
+  write() = isInitial(this) || isUser(this.creator);
 
   name: String,
   creator: UserID,
@@ -27,7 +27,7 @@ isValidMember(room) = room.members[currentUser()] != null &&
 
 type Post {
   // Anyone member of a room can create a post (but cannot delete it).
-  write() = createOnly(this) && isValidMember(this.parent().parent());
+  write() = isInitial(this) && isValidMember(this.parent().parent());
 
   from: UserID,
   message: MessageString,
@@ -39,7 +39,7 @@ type MessageString extends String {
 
 type Member {
   // Anyone can add themselves to a Room with their own nickname.
-  write() = createOnly(this);
+  write() = isInitial(this);
 
   nickname: NicknameString,
   isBanned: Boolean,
@@ -55,7 +55,7 @@ type Timestamped<T> extends T {
 }
 
 type Created extends Number {
-  validate() = this == (prior(this) == null ? now : prior(this));
+  validate() = initial(this, now);
 }
 
 type Modified extends Number {
@@ -73,4 +73,6 @@ type UserID extends String {
 
 isUser(uid) = auth != null && auth.uid == currentUser();
 currentUser() = auth.uid;
-createOnly(location) = prior(location) == null;
+
+initial(value, init) = value == (isInitial(value) ? init : prior(value));
+isInitial(value) = prior(value) == null;

--- a/samples/chat.bolt
+++ b/samples/chat.bolt
@@ -50,10 +50,15 @@ type NicknameString {
 }
 
 type Timestamped<T> extends T {
-  timestamp: Timestamp,
+  created: Created,
+  modified: Modified,
 }
 
-type Timestamp extends Number {
+type Created extends Number {
+  validate() = this == (prior(this) == null ? now : prior(this));
+}
+
+type Modified extends Number {
   validate() = this == now;
 }
 

--- a/samples/chat.bolt
+++ b/samples/chat.bolt
@@ -1,0 +1,63 @@
+/*
+ * Chat room application model.
+ */
+path / is App;
+
+type App {
+  rooms: Room[]
+}
+
+type Room {
+  // Only members can read the contents of a room.
+  read() = isValidMember(this);
+
+  // The creator of a room can delete (or create) any part of a room
+  // including members and posts.
+  write() = createOnly(this) || isUser(this.creator);
+
+  name: String,
+  creator: UserID,
+  members: Map<UserID, Member>,
+  // posts: Timestamped<Post>[],
+  posts: Map<PushID, Timestamped<Post>>,
+}
+
+isValidMember(room) = room.members[currentUser()] != null &&
+  !room.members[currentUser()].isBanned;
+
+type Post {
+  // Anyone member of a room can create a post (but cannot delete it).
+  write() = createOnly(this) && isValidMember(this.parent().parent());
+
+  from: UserID,
+  message: String,
+}
+
+type Member {
+  // Anyone can add themselves to a Room with their own nickname.
+  write() = createOnly(this);
+
+  nickname: String,
+  isBanned: Boolean,
+}
+
+type Timestamped<T> extends T {
+  timestamp: Timestamp,
+}
+
+type Timestamp extends Number {
+  validate() = this == now;
+}
+
+type PushID extends String {
+  validate() = this.length == 20;
+}
+
+type UserID extends String {
+  // Only a user can create content with thier userid.
+  validate() = isUser(this);
+}
+
+isUser(uid) = auth != null && auth.uid == currentUser();
+currentUser() = auth.uid;
+createOnly(location) = prior(location) == null;

--- a/samples/chat.bolt
+++ b/samples/chat.bolt
@@ -1,33 +1,32 @@
 /*
  * Chat room application model.
  */
-path / is App;
-
-type App {
-  rooms: Room[]
+path /rooms is Map<RoomID, RoomInfo>;
+path /posts/$roomid {
+  validate() = getRoomInfo($roomid) != null;
 }
 
-type Room {
-  // Only members can read the contents of a room.
-  read() = isValidMember(this);
+path /posts/$roomid/$postid is Timestamped<Post> {
+  write() = isMember(getRoomInfo($roomid));
+}
 
-  // The creator of a room can delete (or create) any part of a room
-  // including members and posts.
+type RoomInfo {
+  read() = isMember(this) || isUser(this.creator);
   write() = isInitial(this) || isUser(this.creator);
 
-  name: String,
+  name: NameString,
   creator: UserID,
-  members: Map<UserID, Member>,
-  // posts: Timestamped<Post>[],
-  posts: Map<PushID, Timestamped<Post>>,
+  members: Member[],
 }
 
-isValidMember(room) = room.members[currentUser()] != null &&
-  !room.members[currentUser()].isBanned;
+getRoomInfo(id) = prior(root).rooms[id];
+
+isMember(roomInfo) = roomInfo.members[currentUser()] != null &&
+  !roomInfo.members[currentUser()].isBanned;
 
 type Post {
-  // Anyone member of a room can create a post (but cannot delete it).
-  write() = isInitial(this) && isValidMember(this.parent().parent());
+  // Allow create (but not modify/delete).
+  write() = isInitial(this);
 
   from: UserID,
   message: MessageString,
@@ -39,19 +38,19 @@ type MessageString extends String {
 
 type Member {
   // Anyone can add themselves to a Room with their own nickname.
-  write() = isInitial(this);
+  write() = isInitial(this) && isUser(key());
 
-  nickname: NicknameString,
+  nickname: NameString,
   isBanned: Boolean,
 }
 
-type NicknameString {
-  validate() = this.length > 0 && this.length <= 16;
+type NameString {
+  validate() = this.length > 0 && this.length <= 32;
 }
 
 type Timestamped<T> extends T {
   created: Created,
-  modified: Modified,
+  // modified: Modified,
 }
 
 type Created extends Number {
@@ -64,6 +63,10 @@ type Modified extends Number {
 
 type PushID extends String {
   validate() = this.length == 20;
+}
+
+type RoomID extends String {
+  validate() = this.length >= 1 && this.length <= 32;
 }
 
 type UserID extends String {

--- a/samples/chat.bolt
+++ b/samples/chat.bolt
@@ -30,15 +30,23 @@ type Post {
   write() = createOnly(this) && isValidMember(this.parent().parent());
 
   from: UserID,
-  message: String,
+  message: MessageString,
+}
+
+type MessageString extends String {
+  validate() = this.length > 0 && this.length <= 140;
 }
 
 type Member {
   // Anyone can add themselves to a Room with their own nickname.
   write() = createOnly(this);
 
-  nickname: String,
+  nickname: NicknameString,
   isBanned: Boolean,
+}
+
+type NicknameString {
+  validate() = this.length > 0 && this.length <= 16;
 }
 
 type Timestamped<T> extends T {

--- a/samples/chat.bolt
+++ b/samples/chat.bolt
@@ -71,7 +71,7 @@ type UserID extends String {
   validate() = isUser(this);
 }
 
-isUser(uid) = auth != null && auth.uid == currentUser();
+isUser(uid) = auth != null && uid == currentUser();
 currentUser() = auth.uid;
 
 initial(value, init) = value == (isInitial(value) ? init : prior(value));

--- a/samples/chat.json
+++ b/samples/chat.json
@@ -39,7 +39,7 @@
             },
             ".write": "data.val() == null && (newData.parent().parent().child('members').child(auth.uid).val() != null && !(newData.parent().parent().child('members').child(auth.uid).child('isBanned').val() == true))",
             "created": {
-              ".validate": "newData.isNumber() && newData.val() == (data.val() == null ? now : data)"
+              ".validate": "newData.isNumber() && newData.val() == (data.val() == null ? now : data.val())"
             },
             "modified": {
               ".validate": "newData.isNumber() && newData.val() == now"

--- a/samples/chat.json
+++ b/samples/chat.json
@@ -8,11 +8,11 @@
           ".validate": "newData.isString()"
         },
         "creator": {
-          ".validate": "newData.isString() && (auth != null && auth.uid == auth.uid)"
+          ".validate": "newData.isString() && (auth != null && newData.val() == auth.uid)"
         },
         "members": {
           "$key2": {
-            ".validate": "newData.hasChildren(['nickname', 'isBanned']) && auth != null && auth.uid == auth.uid",
+            ".validate": "newData.hasChildren(['nickname', 'isBanned']) && auth != null && $key2 == auth.uid",
             "nickname": {
               ".validate": "newData.val().length > 0 && newData.val().length <= 16"
             },
@@ -29,7 +29,7 @@
           "$key3": {
             ".validate": "newData.hasChildren(['from', 'message', 'created', 'modified']) && $key3.length == 20",
             "from": {
-              ".validate": "newData.isString() && (auth != null && auth.uid == auth.uid)"
+              ".validate": "newData.isString() && (auth != null && newData.val() == auth.uid)"
             },
             "message": {
               ".validate": "newData.isString() && newData.val().length > 0 && newData.val().length <= 140"
@@ -50,7 +50,7 @@
           ".validate": "false"
         },
         ".read": "data.child('members').child(auth.uid).val() != null && !(data.child('members').child(auth.uid).child('isBanned').val() == true)",
-        ".write": "data.val() == null || auth != null && auth.uid == auth.uid"
+        ".write": "data.val() == null || auth != null && newData.child('creator').val() == auth.uid"
       }
     },
     "$other": {

--- a/samples/chat.json
+++ b/samples/chat.json
@@ -27,7 +27,7 @@
         },
         "posts": {
           "$key3": {
-            ".validate": "newData.hasChildren(['from', 'message', 'timestamp']) && $key3.length == 20",
+            ".validate": "newData.hasChildren(['from', 'message', 'created', 'modified']) && $key3.length == 20",
             "from": {
               ".validate": "newData.isString() && (auth != null && auth.uid == auth.uid)"
             },
@@ -38,7 +38,10 @@
               ".validate": "false"
             },
             ".write": "data.val() == null && (newData.parent().parent().child('members').child(auth.uid).val() != null && !(newData.parent().parent().child('members').child(auth.uid).child('isBanned').val() == true))",
-            "timestamp": {
+            "created": {
+              ".validate": "newData.isNumber() && newData.val() == (data.val() == null ? now : data)"
+            },
+            "modified": {
               ".validate": "newData.isNumber() && newData.val() == now"
             }
           }

--- a/samples/chat.json
+++ b/samples/chat.json
@@ -1,20 +1,19 @@
 {
   "rules": {
-    ".validate": "newData.hasChildren()",
     "rooms": {
       "$key1": {
-        ".validate": "newData.hasChildren(['name', 'creator'])",
+        ".validate": "newData.hasChildren(['name', 'creator']) && $key1.length >= 1 && $key1.length <= 32",
         "name": {
-          ".validate": "newData.isString()"
+          ".validate": "newData.val().length > 0 && newData.val().length <= 32"
         },
         "creator": {
           ".validate": "newData.isString() && (auth != null && newData.val() == auth.uid)"
         },
         "members": {
           "$key2": {
-            ".validate": "newData.hasChildren(['nickname', 'isBanned']) && auth != null && $key2 == auth.uid",
+            ".validate": "newData.hasChildren(['nickname', 'isBanned'])",
             "nickname": {
-              ".validate": "newData.val().length > 0 && newData.val().length <= 16"
+              ".validate": "newData.val().length > 0 && newData.val().length <= 32"
             },
             "isBanned": {
               ".validate": "newData.isBoolean()"
@@ -22,39 +21,36 @@
             "$other": {
               ".validate": "false"
             },
-            ".write": "data.val() == null"
-          }
-        },
-        "posts": {
-          "$key3": {
-            ".validate": "newData.hasChildren(['from', 'message', 'created', 'modified']) && $key3.length == 20",
-            "from": {
-              ".validate": "newData.isString() && (auth != null && newData.val() == auth.uid)"
-            },
-            "message": {
-              ".validate": "newData.isString() && newData.val().length > 0 && newData.val().length <= 140"
-            },
-            "$other": {
-              ".validate": "false"
-            },
-            ".write": "data.val() == null && (newData.parent().parent().child('members').child(auth.uid).val() != null && !(newData.parent().parent().child('members').child(auth.uid).child('isBanned').val() == true))",
-            "created": {
-              ".validate": "newData.isNumber() && newData.val() == (data.val() == null ? now : data.val())"
-            },
-            "modified": {
-              ".validate": "newData.isNumber() && newData.val() == now"
-            }
+            ".write": "data.val() == null && (auth != null && $key2 == auth.uid)"
           }
         },
         "$other": {
           ".validate": "false"
         },
-        ".read": "data.child('members').child(auth.uid).val() != null && !(data.child('members').child(auth.uid).child('isBanned').val() == true)",
+        ".read": "data.child('members').child(auth.uid).val() != null && !(data.child('members').child(auth.uid).child('isBanned').val() == true) || auth != null && data.child('creator').val() == auth.uid",
         ".write": "data.val() == null || auth != null && newData.child('creator').val() == auth.uid"
       }
     },
-    "$other": {
-      ".validate": "false"
+    "posts": {
+      "$roomid": {
+        ".validate": "root.child('rooms').child($roomid).val() != null",
+        "$postid": {
+          ".validate": "newData.hasChildren(['from', 'message', 'created'])",
+          "from": {
+            ".validate": "newData.isString() && (auth != null && newData.val() == auth.uid)"
+          },
+          "message": {
+            ".validate": "newData.isString() && newData.val().length > 0 && newData.val().length <= 140"
+          },
+          "$other": {
+            ".validate": "false"
+          },
+          ".write": "data.val() == null && (root.child('rooms').child($roomid).child('members').child(auth.uid).val() != null && !(root.child('rooms').child($roomid).child('members').child(auth.uid).child('isBanned').val() == true))",
+          "created": {
+            ".validate": "newData.isNumber() && newData.val() == (data.val() == null ? now : data.val())"
+          }
+        }
+      }
     }
   }
 }

--- a/samples/chat.json
+++ b/samples/chat.json
@@ -14,7 +14,7 @@
           "$key2": {
             ".validate": "newData.hasChildren(['nickname', 'isBanned']) && auth != null && auth.uid == auth.uid",
             "nickname": {
-              ".validate": "newData.isString()"
+              ".validate": "newData.val().length > 0 && newData.val().length <= 16"
             },
             "isBanned": {
               ".validate": "newData.isBoolean()"
@@ -32,7 +32,7 @@
               ".validate": "newData.isString() && (auth != null && auth.uid == auth.uid)"
             },
             "message": {
-              ".validate": "newData.isString()"
+              ".validate": "newData.isString() && newData.val().length > 0 && newData.val().length <= 140"
             },
             "$other": {
               ".validate": "false"

--- a/samples/chat.json
+++ b/samples/chat.json
@@ -1,0 +1,57 @@
+{
+  "rules": {
+    ".validate": "newData.hasChildren()",
+    "rooms": {
+      "$key1": {
+        ".validate": "newData.hasChildren(['name', 'creator'])",
+        "name": {
+          ".validate": "newData.isString()"
+        },
+        "creator": {
+          ".validate": "newData.isString() && (auth != null && auth.uid == auth.uid)"
+        },
+        "members": {
+          "$key2": {
+            ".validate": "newData.hasChildren(['nickname', 'isBanned']) && auth != null && auth.uid == auth.uid",
+            "nickname": {
+              ".validate": "newData.isString()"
+            },
+            "isBanned": {
+              ".validate": "newData.isBoolean()"
+            },
+            "$other": {
+              ".validate": "false"
+            },
+            ".write": "data.val() == null"
+          }
+        },
+        "posts": {
+          "$key3": {
+            ".validate": "newData.hasChildren(['from', 'message', 'timestamp']) && $key3.length == 20",
+            "from": {
+              ".validate": "newData.isString() && (auth != null && auth.uid == auth.uid)"
+            },
+            "message": {
+              ".validate": "newData.isString()"
+            },
+            "$other": {
+              ".validate": "false"
+            },
+            ".write": "data.val() == null && (newData.parent().parent().child('members').child(auth.uid).val() != null && !(newData.parent().parent().child('members').child(auth.uid).child('isBanned').val() == true))",
+            "timestamp": {
+              ".validate": "newData.isNumber() && newData.val() == now"
+            }
+          }
+        },
+        "$other": {
+          ".validate": "false"
+        },
+        ".read": "data.child('members').child(auth.uid).val() != null && !(data.child('members').child(auth.uid).child('isBanned').val() == true)",
+        ".write": "data.val() == null || auth != null && auth.uid == auth.uid"
+      }
+    },
+    "$other": {
+      ".validate": "false"
+    }
+  }
+}

--- a/samples/multi-update.json
+++ b/samples/multi-update.json
@@ -2,7 +2,7 @@
   "rules": {
     "secret": {
       "$uid": {
-        ".validate": "newData.parent().parent().child('users').child($uid).val() != null && newData.isString()",
+        ".validate": "newData.isString() && newData.parent().parent().child('users').child($uid).val() != null",
         ".read": "auth != null && auth.uid == $uid"
       }
     },

--- a/samples/serialized.bolt
+++ b/samples/serialized.bolt
@@ -1,0 +1,23 @@
+/*
+ * Demonstrate using a generic serialized update type.
+ * Updates can only be made if the counter property
+ * is created with value 1, and each update must
+ * increment the value by 1 (conflicting, non-serialized updates
+ * will fail).
+ */
+path /products is Map<String, Serialized<Product>> {
+  read() = true;
+}
+
+type Product {
+  name: String,
+  cost: Number,
+}
+
+type Serialized<T> extends T {
+  counter: Counter,
+}
+
+type Counter extends Number {
+  validate() = (prior(this) == null && this == 1) || this == prior(this) + 1;
+}

--- a/samples/serialized.json
+++ b/samples/serialized.json
@@ -1,0 +1,22 @@
+{
+  "rules": {
+    "products": {
+      "$key1": {
+        ".validate": "newData.hasChildren(['name', 'cost', 'counter'])",
+        "name": {
+          ".validate": "newData.isString()"
+        },
+        "cost": {
+          ".validate": "newData.isNumber()"
+        },
+        "$other": {
+          ".validate": "false"
+        },
+        "counter": {
+          ".validate": "newData.isNumber() && (data.val() == null && newData.val() == 1 || newData.val() == data.val() + 1)"
+        }
+      },
+      ".read": "true"
+    }
+  }
+}

--- a/src/firebase-rest.ts
+++ b/src/firebase-rest.ts
@@ -28,6 +28,7 @@ import uuid = require('node-uuid');
 var FirebaseTokenGenerator = require('firebase-token-generator');
 
 var FIREBASE_HOST = 'firebaseio.com';
+var DEBUG_HEADER = 'x-firebase-auth-debug';
 
 export var RULES_LOCATION =  '/.settings/rules';
 export var TIMESTAMP = {".sv": "timestamp"};
@@ -114,7 +115,13 @@ function request(options, content, debug): Promise<string> {
         var result: string = chunks.join('');
         log("Result (" + res.statusCode + "): '" + result + "'");
         if (Math.floor(res.statusCode / 100) !== 2) {
-          reject(new Error("Status = " + res.statusCode + " " + result));
+          let message = "Status = " + res.statusCode + " " + result;
+          if (res.headers[DEBUG_HEADER]) {
+            let formattedHeader = res.headers[DEBUG_HEADER].split(' /').join('\n  /');
+            log(formattedHeader);
+            message += "\n" + formattedHeader;
+          }
+          reject(new Error(message));
         } else {
           resolve(result);
         }
@@ -141,4 +148,65 @@ export function generateUidAuthToken(secret, opts) {
   var uid = uuid.v4();
   var token = tokenGenerator.createToken({ uid: uid }, opts);
   return { uid: uid, token: token };
+}
+
+/**
+ * Fancy ID generator that creates 20-character string identifiers with the following properties:
+ *
+ * 1. They're based on timestamp so that they sort *after* any existing ids.
+ * 2. They contain 72-bits of random data after the timestamp so that IDs won't collide with other clients' IDs.
+ * 3. They sort *lexicographically* (so the timestamp is converted to characters that will sort properly).
+ * 4. They're monotonically increasing.  Even if you generate more than one in the same timestamp, the
+ *    latter ones will sort after the former ones.  We do this by using the previous random bits
+ *    but "incrementing" them by 1 (only in the case of a timestamp collision).
+ */
+
+// Modeled after base64 web-safe chars, but ordered by ASCII.
+var PUSH_CHARS = '-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz';
+
+// Timestamp of last push, used to prevent local collisions if you push twice in one ms.
+var lastPushTime = 0;
+
+// We generate 72-bits of randomness which get turned into 12 characters and appended to the
+// timestamp to prevent collisions with other clients.  We store the last characters we
+// generated because in the event of a collision, we'll use those same characters except
+// "incremented" by one.
+var lastRandChars = [];
+
+export function generatePushID(): string {
+  var now = new Date().getTime();
+  var duplicateTime = (now === lastPushTime);
+  lastPushTime = now;
+
+  var timeStampChars = new Array(8);
+  for (var i = 7; i >= 0; i--) {
+    timeStampChars[i] = PUSH_CHARS.charAt(now % 64);
+    // NOTE: Can't use << here because javascript will convert to int and lose the upper bits.
+    now = Math.floor(now / 64);
+  }
+  if (now !== 0) {
+    throw new Error('We should have converted the entire timestamp.');
+  }
+
+  var id = timeStampChars.join('');
+
+  if (!duplicateTime) {
+    for (i = 0; i < 12; i++) {
+      lastRandChars[i] = Math.floor(Math.random() * 64);
+    }
+  } else {
+    // If the timestamp hasn't changed since last push, use the same random number, except incremented by 1.
+    for (i = 11; i >= 0 && lastRandChars[i] === 63; i--) {
+      lastRandChars[i] = 0;
+    }
+    lastRandChars[i]++;
+  }
+  for (i = 0; i < 12; i++) {
+    id += PUSH_CHARS.charAt(lastRandChars[i]);
+  }
+  if (id.length !== 20) {
+    throw new Error('Length should be 20.');
+  }
+
+  return id;
 }

--- a/src/rules-generator.ts
+++ b/src/rules-generator.ts
@@ -654,8 +654,8 @@ export class Generator {
         }
       } else if (expOp.op === '?:') {
         expOp.args[0] = booleanExpression(expOp.args[0]);
-        expOp.args[1] = subExpression(expOp.args[1]);
-        expOp.args[2] = subExpression(expOp.args[2]);
+        expOp.args[1] = valueExpression(expOp.args[1]);
+        expOp.args[2] = valueExpression(expOp.args[2]);
       } else {
         for (let i = 0; i < expOp.args.length; i++) {
           expOp.args[i] = valueExpression(expOp.args[i]);

--- a/src/test/chat-test.ts
+++ b/src/test/chat-test.ts
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/// <reference path="../typings/node.d.ts" />
+
+var bolt = (typeof(window) !== 'undefined' && window.bolt) || require('../bolt');
+var rulesSuite = bolt.rulesSuite;
+var secrets = require('../../auth-secrets');
+
+rulesSuite("Chat", function(test) {
+  var uid = test.uid;
+
+  test.database(secrets.APP, secrets.SECRET);
+  test.rules('samples/chat');
+
+  function makeMikesRoom(rules) {
+    return rules
+      .as('mike')
+      .at('/rooms/mikes-room')
+      .write({
+        name: "Mike's room",
+        creator: uid('mike'),
+      });
+  }
+
+  test("Create and Delete Room.", function(rules) {
+    makeMikesRoom(rules)
+      .succeeds("Create empty room.")
+
+      .write(null)
+      .fails("Owner can delete room.");
+  });
+
+  test("Forge Creator of Room.", function(rules) {
+    rules
+      .as('mike')
+      .at('/rooms/mikes-room')
+      .write({
+        name: "Mike's room",
+        creator: uid('fred'),
+      })
+      .fails("Can't create forged room.");
+  });
+
+  test("Join a Room.", function(rules) {
+    makeMikesRoom(rules)
+      .at('/rooms/mikes-room/members/' + uid('mike'))
+      .write({
+        nickname: 'Mike',
+        isBanned: false
+      })
+      .succeeds("Add self to room members.")
+
+      .at('/rooms/mikes-room/members/' + uid('fred'))
+      .write({
+        nickname: 'Fred',
+        isBanned: false
+      })
+      .succeeds("Creator can add other members.")
+
+      .as('barney')
+      .at('/rooms/mikes-room/members/' + uid('barney'))
+      .write({
+        nickname: 'Barney',
+        isBanned: false
+      })
+      .succeeds("User can add self to a room.")
+
+      .as('mike')
+      .at('/rooms/mikes-room/members/' + uid('fred'))
+      .write(null)
+      .succeeds("Creator can remove a member.")
+    ;
+  });
+
+  test("Banning and unbanning.", function(rules) {
+    makeMikesRoom(rules)
+      .at('/rooms/mikes-room/members/' + uid('mike'))
+
+      .as('barney')
+      .at('/rooms/mikes-room/members/' + uid('barney'))
+      .write({
+        nickname: 'Barney',
+        isBanned: false
+      })
+      .succeeds("User can add self to a room.")
+
+      .as('mike')
+      .at('/rooms/mikes-room/members/' + uid('barney') + '/isBanned')
+      .write(true)
+      .succeeds("Creator can ban a member.")
+
+      .as('barney')
+      .at('/rooms/mikes-room/members/' + uid('barney'))
+      .write(null)
+      .fails("User tries to delete self.")
+
+      .as('barney')
+      .at('/rooms/mikes-room/members/' + uid('barney'))
+      .write({
+        nickname: 'Barney',
+        isBanned: false
+      })
+      .fails("User tries to rejoin")
+
+      .as('barney')
+      .at('/rooms/mikes-room/members/' + uid('barney') + '/isBanned')
+      .write(false)
+      .fails("User tries to unban self.")
+
+      .as('mike')
+      .at('/rooms/mikes-room/members/' + uid('barney') + '/isBanned')
+      .write(false)
+      .succeeds("Room creator can unban user.")
+    ;
+  });
+
+  test("Posting.", function(rules) {
+    makeMikesRoom(rules)
+      .at('/posts/mikes-room')
+      .push({
+        from: uid('mike'),
+        message: "Hello, world!",
+        created: test.TIMESTAMP,
+      })
+      .fails("Owner can't write into room until he is a member.")
+
+      .at('/rooms/mikes-room/members/' + uid('mike'))
+      .write({
+        nickname: 'Mike',
+        isBanned: false
+      })
+      .succeeds("Add self to room members.")
+
+      .at('/posts/mikes-room')
+      .push({
+        from: uid('mike'),
+        message: "Hello, world!",
+        created: test.TIMESTAMP,
+      })
+      .succeeds("Owner-member can post to room.")
+
+      .as('barney')
+      .at('/posts/mikes-room')
+      .push({
+        from: uid('barney'),
+        message: "Hello, Mike!",
+        created: test.TIMESTAMP,
+      })
+      .fails("Non-members cannot post.")
+
+      .as('barney')
+      .at('/rooms/mikes-room/members/' + uid('barney'))
+      .write({
+        nickname: 'Barney',
+        isBanned: false
+      })
+      .succeeds("User can add self to a room.")
+
+      .as('barney')
+      .at('/posts/mikes-room')
+      .push({
+        from: uid('barney'),
+        message: "Hello, Mike!",
+        created: test.TIMESTAMP,
+      })
+      .succeeds("Members can post.")
+
+      .as('mike')
+      .at('/rooms/mikes-room/members/' + uid('barney') + '/isBanned')
+      .write(true)
+      .succeeds("Creator can ban a member.")
+
+      .as('barney')
+      .at('/posts/mikes-room')
+      .push({
+        from: uid('barney'),
+        message: "Hello, Mike!",
+        created: test.TIMESTAMP,
+      })
+      .fails("Banned members cannot post.")
+    ;
+  });
+});

--- a/src/test/firebase-rest-test.ts
+++ b/src/test/firebase-rest-test.ts
@@ -19,6 +19,8 @@
 import Promise = require('promise');
 import rest = require('../firebase-rest');
 var secrets = require('../../auth-secrets');
+import chai = require('chai');
+var assert = chai.assert;
 
 var TEST_LOCATION = '/rest-test';
 
@@ -66,5 +68,12 @@ suite("Firebase REST Tests", function() {
       .catch(function(error) {
         return true;
       });
+  });
+
+  test("PushID", function() {
+    let id1 = rest.generatePushID();
+    let id2 = rest.generatePushID();
+    assert.equal(id1.length, 20);
+    assert.notEqual(id1, id2);
   });
 });

--- a/src/test/generator-test.ts
+++ b/src/test/generator-test.ts
@@ -73,6 +73,7 @@ suite("Rules Generator Tests", function() {
                  "generics",
                  "groups",
                  "multi-update",
+                 "chat",
                 ];
 
     helper.dataDrivenTest(files, function(filename) {

--- a/src/test/generator-test.ts
+++ b/src/test/generator-test.ts
@@ -74,6 +74,7 @@ suite("Rules Generator Tests", function() {
                  "groups",
                  "multi-update",
                  "chat",
+                 "serialized",
                 ];
 
     helper.dataDrivenTest(files, function(filename) {


### PR DESCRIPTION
Relaxing restrictions about read and write rules in schema.

After implementing more sample rules, I've come to the realization that restricting read and write rules to only path statements is stifling and causes clumsy repetition of two parallel data models (one in the path domain, and the other in the type domain).

This PR removes the (arbitrary) restriction (and adds some demonstrative samples).  Users can still factor their rules into pure type vs pure authorization if they so choose.

@TristonianJones 