### PR TITLE
Deprecate fn(x) = exp style of function definition.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,1 +1,2 @@
 changed - Path expressions should now use path template syntax instead of wildcard variables.
+changed - Deprecate fn(x) = exp; function definition format (with deprecation warning).

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -28,12 +28,12 @@ and overwrite all your data. In Bolt, these default permissions can be written a
 [all_access.bolt](../samples/all_access.bolt)
 ```javascript
 path / {
-  read() = true;
-  write() = true;
+  read() { true }
+  write() { true }
 }
 ```
 
-The `read() = true` and `write() = true` methods allow everyone to read and write this location
+The `read() { true }` and `write() { true }` methods allow everyone to read and write this location
 (and all children under this location). You can also use more complex expressions instead of
 `true`.  When the expression evaluates to `true` the read or write operation is allowed.
 
@@ -79,16 +79,16 @@ _posts.bolt_
 ```javascript
 // Allow anyone to read the list of Posts.
 path /posts {
-  read() = true;
+  read() { true }
 }
 
 // All individual Posts are writable by anyone.
 path /posts/{id} is Post {
-  write() = true;
+  write() { true }
 }
 
 type Post {
-  validate() = this.message.length <= 140;
+  validate() { this.message.length <= 140 }
 
   message: String,
   from: String
@@ -106,7 +106,7 @@ captured variable `id` being equal to (the string) '123'.
 The Post type allows for exactly two string properties in each post (message and
 from). It also ensures that no message is longer than 140 characters.
 
-Bolt type statements can contain a `validate()` method (defined as `validate() = <expression>`,
+Bolt type statements can contain a `validate()` method (defined as `validate() { <expression>`,
 where the expression evaluates to `true` if the data is valid (can be saved to the
 database). When the expression evaluates to `false`, the attempt to write the data will return
 an error to the Firebase client and the database will be unmodified.
@@ -202,7 +202,7 @@ type Room {
 }
 
 type NameString extends String {
-  validate() = this.length > 0 && this.length <= 32;
+  validate() { this.length > 0 && this.length <= 32 }
 }
 ```
 
@@ -255,8 +255,8 @@ definitions look just like _type_ and _path_ methods, except they can also accep
 
 ```javascript
 path /users/$userid is User {
-  read() = true;
-  write() = isCurrentUser($userid);
+  read() { true }
+  write() { isCurrentUser($userid) }
 }
 
 type User {
@@ -266,7 +266,7 @@ type User {
 
 // Define isCurrentUser() function to test if the given user id
 // matches the currently signed-in user.
-isCurrentUser(uid) = auth != null && auth.uid == uid;
+isCurrentUser(uid) { auth != null && auth.uid == uid }
 ```
 
 ```JSON
@@ -308,7 +308,7 @@ path /posts/$id is Post;
 
 type Post {
   // Make sure that the only value allowed to be written is now.
-  validate() = this.modified == now;
+  validate() { this.modified == now }
 
   message: String,
   modified: Number
@@ -322,8 +322,8 @@ A handy way to express this is to use a user-defined type for the CurrentTimesta
 
 ```javascript
 path /posts/$id is Post {
-  read() = true;
-  write() = true;
+  read() { true }
+  write() { true }
 }
 
 type Post {
@@ -332,7 +332,7 @@ type Post {
 }
 
 type CurrentTimestamp extends Number {
-  validate() = this == now;
+  validate() { this == now }
 }
 ```
 
@@ -341,8 +341,8 @@ when first written, and never change thereafter:
 
 ```javascript
 path /posts/$id is Post {
-  read() = true;
-  write() = true;
+  read() { true }
+  write() { true }
 }
 
 type Post {
@@ -352,16 +352,16 @@ type Post {
 }
 
 type CurrentTimestamp extends Number {
-  validate() = this == now;
+  validate() { this == now }
 }
 
 type InitialTimestamp extends Number {
-  validate() = initial(this, now);
+  validate() { initial(this, now) }
 }
 
 // Returns true if the value is intialized to init, or if it retains it's prior
 // value, otherwise.
-initial(value, init) = value == (prior(value) == null ? init : prior(value));
+initial(value, init) { value == (prior(value) == null ? init : prior(value)) }
 ```
 
 Note the special function `prior(ref)` - returns the previous value stored at a given database location
@@ -401,8 +401,8 @@ to define the Timestamp example above is:
 ```javascript
 // Note the use of Timestamped version of a Post type.
 path /posts/$id is Timestamped<Post> {
-  read() = true;
-  write() = true;
+  read() { true }
+  write() { true }
 }
 
 type Post {
@@ -415,16 +415,16 @@ type Timestamped<T> extends T {
 }
 
 type CurrentTimestamp extends Number {
-  validate() = this == now;
+  validate() { this == now }
 }
 
 type InitialTimestamp extends Number {
-  validate() = initial(this, now);
+  validate() { initial(this, now) }
 }
 
 // Returns true if the value is intialized to init, or retains it's prior
 // value, otherwise.
-initial(value, init) = value == (prior(value) == null ? init : prior(value));
+initial(value, init) { value == (prior(value) == null ? init : prior(value)) }
 ```
 
 ```JSON
@@ -463,34 +463,34 @@ Rules](https://www.firebase.com/docs/security/guide/user-security.html#section-r
 // Room Names
 //
 path /rooms_names is String[] {
-  read() = isSignedIn();
+  read() { isSignedIn() }
 }
 
-getRoomName(id) = prior(root.room_names[id]);
+getRoomName(id) { prior(root.room_names[id]) }
 
 //
 // Room Members
 //
 path /members/$room_id {
-  read() = isRoomMember($room_id);
+  read() { isRoomMember($room_id) }
 }
 
 path /members/$room_id/$user_id is NameString {
-  write() = isCurrentUser($user_id);
+  write() { isCurrentUser($user_id) }
 }
 
-isRoomMember(room_id) = isSignedIn() && prior(root.members[room_id][auth.uid]) != null;
+isRoomMember(room_id) { isSignedIn() && prior(root.members[room_id][auth.uid]) != null }
 
 //
 // Messages
 //
 path /messages/$room_id {
-  read() = isRoomMember($room_id);
-  validate() = getRoomName($room_id) != null;
+  read() { isRoomMember($room_id) }
+  validate() { getRoomName($room_id) != null }
 }
 
 path /messages/$room_id/$message_id is Message {
-  write() = createOnly(this) && isRoomMember($room_id);
+  write() { createOnly(this) && isRoomMember($room_id) }
 }
 
 type Message {
@@ -500,26 +500,26 @@ type Message {
 }
 
 type MessageString extends String {
-  validate() = this.length > 0 && this.length < 50;
+  validate() { this.length > 0 && this.length < 50 }
 }
 
 //
 // Helper Types
 //
 type CurrentTimestamp extends Number {
-  validate() = this == now;
+  validate() { this == now }
 }
 
 type NameString {
-  validate() = this.length > 0 && this.length < 20;
+  validate() { this.length > 0 && this.length < 20 }
 }
 
 //
 // Helper Functions
 //
-isCurrentUser(uid) = isSignedIn() && auth.uid == uid;
-isSignedIn() = auth != null;
-createOnly(value) = prior(value) == null && value != null;
+isCurrentUser(uid) { isSignedIn() && auth.uid == uid }
+isSignedIn() { auth != null }
+createOnly(value) { prior(value) == null && value != null }
 ```
 
 ```JSON

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -106,7 +106,7 @@ captured variable `id` being equal to (the string) '123'.
 The Post type allows for exactly two string properties in each post (message and
 from). It also ensures that no message is longer than 140 characters.
 
-Bolt type statements can contain a `validate()` method (defined as `validate() { <expression>`,
+Bolt type statements can contain a `validate()` method (defined as `validate() { <expression> }`,
 where the expression evaluates to `true` if the data is valid (can be saved to the
 database). When the expression evaluates to `false`, the attempt to write the data will return
 an error to the Firebase client and the database will be unmodified.

--- a/docs/language.md
+++ b/docs/language.md
@@ -33,7 +33,7 @@ type MyType [extends BaseType] {
   property2: Type,
   ...
 
-  validate() = <validation expression>;
+  validate() { <validation expression> }
   }
 }
 ```
@@ -67,11 +67,11 @@ Any of the built-in scalar types can be _extended_ by adding a validation expres
 
 ```javascript
 type ShortString extends String {
-  validate() = this.length < 32;
+  validate() { this.length < 32 }
 }
 
 type Percentage extends Number {
-  validate() = this >=0 && this <= 100;
+  validate() { this >=0 && this <= 100 }
 }
 ```
 
@@ -103,7 +103,7 @@ type Model {
 }
 
 type ProductID extends String {
-  validate() = this.length <= 20;
+  validate() { this.length <= 20 }
 }
 ```
 
@@ -145,11 +145,11 @@ A path statement provides access and validation rules for data stored at a given
 
 ```javascript
 path /path/to/data [is Type] {
-  read() = <true-iff-reading-this-path-is-allowed>;
+  read() { <true-iff-reading-this-path-is-allowed> }
 
-  write() = <true-iff-writing-this-path-is-allowed>;
+  write() { <true-iff-writing-this-path-is-allowed> }
 
-  validate() = <additional-validation-rules>;
+  validate() { <additional-validation-rules> }
 }
 ```
 
@@ -174,10 +174,10 @@ an expression as a variable parameter:
 ```javascript
 path /users/{uid} is User {
   // Anyone can read a User's information.
-  read() = true;
+  read() { true }
 
   // Only an authenticated user can write their information.
-  write() = auth != null && auth.uid == uid;
+  write() { auth != null && auth.uid == uid }
 }
 ```
 
@@ -237,7 +237,7 @@ and one of its properties:
 path /products is Product[];
 
 type Product {
-  validate() = this.id == key();
+  validate() { this.id == key() }
 
   id: String,
   name: String
@@ -258,7 +258,7 @@ function isUser(uid) {
 
 function isUser(uid) { auth != null && auth.uid == uid }
 
-isUser(uid) = auth != null && auth.uid == uid;
+isUser(uid) { auth != null && auth.uid == uid }
 ```
 
 Similarly, methods in path and type statements can use the abbreviated functional form (all
@@ -266,8 +266,8 @@ these are equivalent):
 
 ```javascript
 write() { return this.user == auth.uid; }
+write() { this.user == auth.uid; }
 write() { this.user == auth.uid }
-write() = this.user == auth.uid;
 ```
 
 # Expressions
@@ -295,10 +295,10 @@ not identical in Bolt.  This section demonstrates how equivalent behavior is ach
 
 API | Bolt Equivalent
 ----| ---------------
-".read" : "exp" | read() { return exp; }
-".write" : "exp" | write() { return exp; }
-".validate": "exp" | validate() { return exp; }
-".indexOn": [ "prop", ...] | index() { return [ "prop", ... ] }
+".read" : "exp" | read() { exp }
+".write" : "exp" | write() { exp }
+".validate": "exp" | validate() { exp }
+".indexOn": [ "prop", ...] | index() { [ "prop", ... ] }
 
 ## Variables
 

--- a/samples/all_access.bolt
+++ b/samples/all_access.bolt
@@ -1,5 +1,5 @@
 // Equivalent to the default (most-permissive) Firebase rule.
 path / {
-  read() = true;
-  write() = true;
+  read() { true }
+  write() { true }
 }

--- a/samples/chat.bolt
+++ b/samples/chat.bolt
@@ -3,49 +3,50 @@
  */
 path /rooms is Map<RoomID, RoomInfo>;
 path /posts/{roomid} {
-  validate() = getRoomInfo(roomid) != null;
+  validate() { getRoomInfo(roomid) != null }
 }
 
 path /posts/{roomid}/{postid} is Timestamped<Post> {
-  write() = isMember(getRoomInfo(roomid));
+  write() { isMember(getRoomInfo(roomid)) }
 }
 
 type RoomInfo {
-  read() = isMember(this) || isUser(this.creator);
-  write() = isInitial(this) || isUser(this.creator);
+  read() { isMember(this) || isUser(this.creator) }
+  write() { isInitial(this) || isUser(this.creator) }
 
   name: NameString,
   creator: UserID,
   members: Member[],
 }
 
-getRoomInfo(id) = prior(root).rooms[id];
+getRoomInfo(id) { prior(root).rooms[id] }
 
-isMember(roomInfo) = roomInfo.members[currentUser()] != null &&
-  !roomInfo.members[currentUser()].isBanned;
+isMember(roomInfo) {
+  roomInfo.members[currentUser()] != null && !roomInfo.members[currentUser()].isBanned
+}
 
 type Post {
   // Allow create (but not modify/delete).
-  write() = isInitial(this);
+  write() { isInitial(this) }
 
   from: UserID,
   message: MessageString,
 }
 
 type MessageString extends String {
-  validate() = this.length > 0 && this.length <= 140;
+  validate() { this.length > 0 && this.length <= 140 }
 }
 
 type Member {
   // Anyone can add themselves to a Room with their own nickname.
-  write() = isInitial(this) && isUser(key());
+  write() { isInitial(this) && isUser(key()) }
 
   nickname: NameString,
   isBanned: Boolean,
 }
 
 type NameString {
-  validate() = this.length > 0 && this.length <= 32;
+  validate() { this.length > 0 && this.length <= 32 }
 }
 
 type Timestamped<T> extends T {
@@ -54,28 +55,28 @@ type Timestamped<T> extends T {
 }
 
 type Created extends Number {
-  validate() = initial(this, now);
+  validate() { initial(this, now) }
 }
 
 type Modified extends Number {
-  validate() = this == now;
+  validate() { this == now }
 }
 
 type PushID extends String {
-  validate() = this.length == 20;
+  validate() { this.length == 20 }
 }
 
 type RoomID extends String {
-  validate() = this.length >= 1 && this.length <= 32;
+  validate() { this.length >= 1 && this.length <= 32 }
 }
 
 type UserID extends String {
   // Only a user can create content with thier userid.
-  validate() = isUser(this);
+  validate() { isUser(this) }
 }
 
-isUser(uid) = auth != null && uid == currentUser();
-currentUser() = auth.uid;
+isUser(uid) { auth != null && uid == currentUser() }
+currentUser() { auth.uid }
 
-initial(value, init) = value == (isInitial(value) ? init : prior(value));
-isInitial(value) = prior(value) == null;
+initial(value, init) { value == (isInitial(value) ? init : prior(value)) }
+isInitial(value) { prior(value) == null }

--- a/samples/generics.bolt
+++ b/samples/generics.bolt
@@ -1,5 +1,5 @@
 path / is App {
-  read() = true;
+  read() { true }
 }
 
 type App {
@@ -13,16 +13,16 @@ type User {
 }
 
 type Product {
-  validate() = key() == this.id;
+  validate() { key() == this.id }
 
   id: ProductID,
   cost: Number
 }
 
 type ProductID extends String {
-  validate() = this.length <= 20;
+  validate() { this.length <= 20 }
 }
 
 type PushID extends String {
-  validate() = this.length == 20;
+  validate() { this.length == 20 }
 }

--- a/samples/groups.bolt
+++ b/samples/groups.bolt
@@ -5,7 +5,7 @@
 path /groups/{gid} is Group;
 
 type Group {
-  validate() = members != null;
+  validate() { members != null }
 
   members: Map<TenKeys, User>
 }
@@ -16,5 +16,5 @@ type User {
 }
 
 type TenKeys extends String {
-  validate() = this.length == 1 && this >= '0' && this <= '9';
+  validate() { this.length == 1 && this >= '0' && this <= '9' }
 }

--- a/samples/mail.bolt
+++ b/samples/mail.bolt
@@ -16,19 +16,19 @@
 path /users/{userid} {
   // Inbox
   /inbox/{msg} is Message {
-    read() = isCurrentUser(userid);
-    write() = isNew(this) || isCurrentUser(userid);
+    read() { isCurrentUser(userid) }
+    write() { isNew(this) || isCurrentUser(userid) }
   }
 
   // Outbox
   /outbox/{msg} is Message {
-    read() = isCurrentUser(userid);
-    write() = isCurrentUser(userid);
+    read() { isCurrentUser(userid) }
+    write() { isCurrentUser(userid) }
   }
 }
 
 type Message {
-  validate() = isNew(this) && isCurrentUser(this.from);
+  validate() { isNew(this) && isCurrentUser(this.from) }
 
   from: UserID,
   to: UserID,
@@ -37,6 +37,6 @@ type Message {
 
 type UserID extends String;
 
-isNew(ref) = prior(ref) == null;
+isNew(ref) { prior(ref) == null }
 
-isCurrentUser(userid) = auth != null && auth.uid == userid;
+isCurrentUser(userid) { auth != null && auth.uid == userid }

--- a/samples/map-scalar.bolt
+++ b/samples/map-scalar.bolt
@@ -8,4 +8,6 @@ type Test {
 }
 
 type AliasString extends ShortString;
-type ShortString extends String { validate() = this.length >= 0 && this.length <= 16; }
+type ShortString extends String {
+  validate() { this.length >= 0 && this.length <= 16 }
+}

--- a/samples/multi-update.bolt
+++ b/samples/multi-update.bolt
@@ -6,17 +6,17 @@
 // are only updated when the other one exists.
 
 path /secret/{uid} is String {
-  read() = isUser(uid);
-  validate() = root.users[uid] != null;
+  read() { isUser(uid) }
+  validate() { root.users[uid] != null }
 }
 
 path /users/{uid} is User {
-  read() = true;
-  validate() = root.secret[uid] != null;
+  read() { true }
+  validate() { root.secret[uid] != null }
 }
 
 type User {
   name: String
 }
 
-isUser(uid) = auth != null && auth.uid == uid;
+isUser(uid) { auth != null && auth.uid == uid }

--- a/samples/regexp.bolt
+++ b/samples/regexp.bolt
@@ -1,6 +1,6 @@
 path /  {
-  read() = true;
-  write() = true;
+  read() { true }
+  write() { true }
 }
 
 path /ss is SocialSecurity;
@@ -13,40 +13,40 @@ path /date is ISODate;
 path /slug is Slug;
 
 type SocialSecurity extends String {
-  validate() = this.test(/^\d\d\d-\d\d-\d\d\d\d$/);
+  validate() { this.test(/^\d\d\d-\d\d-\d\d\d\d$/) }
 }
 
 // Only an integer string
 type IntegerString extends String {
-  validate() = this.test(/^-?\d+$/);
+  validate() { this.test(/^-?\d+$/) }
 }
 
 // A floating point number (or integer).
 type FloatString extends String {
-  validate() = this.test(/^-?(\d+\.?\d*|\.\d+)$/);
+  validate() { this.test(/^-?(\d+\.?\d*|\.\d+)$/) }
 }
 
 // An integral number (no fractional part)
 type Integer extends Number {
-  validate() = (this + '').test(/^-?\d+$/);
+  validate() { (this + '').test(/^-?\d+$/) }
 }
 
 // Only letters
 type Alpha extends String {
-  validate() = this.test(/^[a-z]+$/i);
+  validate() { this.test(/^[a-z]+$/i) }
 }
 
 // YYYY is 20th or 21st century
 type Year extends String {
-  validate() = this.test(/^(19|20)\d\d$/);
+  validate() { this.test(/^(19|20)\d\d$/) }
 }
 
 // YYYY-MM-DD in 20th or 21st century
 // Note: Does not validate day-of-month is valid.
 type ISODate extends String {
-  validate() = this.test(/^(19|20)\d\d-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$/);
+  validate() { this.test(/^(19|20)\d\d-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$/) }
 }
 
 type Slug extends String {
-  validate() = this.test(/^([a-z0-9]+-)+[a-z0-9]+$/);
+  validate() { this.test(/^([a-z0-9]+-)+[a-z0-9]+$/) }
 }

--- a/samples/serialized.bolt
+++ b/samples/serialized.bolt
@@ -6,7 +6,7 @@
  * will fail).
  */
 path /products is Map<String, Serialized<Product>> {
-  read() = true;
+  read() { true }
 }
 
 type Product {
@@ -19,5 +19,5 @@ type Serialized<T> extends T {
 }
 
 type Counter extends Number {
-  validate() = (prior(this) == null && this == 1) || this == prior(this) + 1;
+  validate() { (prior(this) == null && this == 1) || this == prior(this) + 1 }
 }

--- a/samples/user-security.bolt
+++ b/samples/user-security.bolt
@@ -14,49 +14,51 @@
 // See https://www.firebase.com/docs/security/guide/user-security.html
 
 path /room_names {
-  read() = auth != null;
+  read() { auth != null }
 
   /{room_id} is String;
 }
 
 path /members/{room_id} {
-  read() = this[auth.uid] != null;
+  read() { this[auth.uid] != null }
 
   /{user_id} is Nickname {
-    write() = isCurrentUser(user_id);
+    write() { isCurrentUser(user_id) }
   }
 }
 
 path /messages/{room_id} {
-  read() = root.room_names[room_id] != null;
+  read() { root.room_names[room_id] != null }
 
   /{message_id} is Message {
-    write() = root.members[room_id][auth.uid] != null;
+    write() { root.members[room_id][auth.uid] != null }
   }
 }
 
 type Nickname extends String {
-  validate() = this.length > 0 && this.length < 20;
+  validate() { this.length > 0 && this.length < 20 }
 }
 
 type UserID extends String {
-  validate() = isCurrentUser(this);
+  validate() { isCurrentUser(this) }
 }
 
 type MessageString extends String {
-  validate() = this.length > 0 && this.length < 50;
+  validate() { this.length > 0 && this.length < 50 }
 }
 
-type Timestamp extends Number { validate() = this <= now; }
+type Timestamp extends Number {
+  validate() { this <= now }
+}
 
 type Message {
-  validate() = isNew(this);
+  validate() { isNew(this) }
 
   user: UserID,
   message: MessageString,
   timestamp: Timestamp
 }
 
-isCurrentUser(id) = auth != null && auth.uid == id;
+isCurrentUser(id) { auth != null && auth.uid == id }
 
-isNew(ref) = prior(ref) == null;
+isNew(ref) { prior(ref) == null }

--- a/samples/userdoc.bolt
+++ b/samples/userdoc.bolt
@@ -64,13 +64,13 @@ path /permissions {
   }
 }
 
-isLoggedIn() = auth != null;
-isCurrentUser(userid) = currentUser() == userid;
-currentUser() = auth.uid;
-fullId(userid, ownerid, docid) = userid + '|' + ownerid + '|' + docid;
-hasPermission(ownerid, docid, p) = root.permissions[fullId(currentUser(), ownerid, docid)][p];
-docIsOwnedBy(docid, userid) = root.documents[userid][docid] != null;
-userExists(userid) = root.users[userid] != null;
+isLoggedIn() { auth != null }
+isCurrentUser(userid) { currentUser() == userid }
+currentUser() { auth.uid }
+fullId(userid, ownerid, docid) { userid + '|' + ownerid + '|' + docid }
+hasPermission(ownerid, docid, p) { root.permissions[fullId(currentUser(), ownerid, docid)][p] }
+docIsOwnedBy(docid, userid) { root.documents[userid][docid] != null }
+userExists(userid) { root.users[userid] != null }
 
 // TODO: Use .match instead - needs specific translator for string->regexp in language.
-isISODate(date) = beginsWith(date, '2015-');
+isISODate(date) { beginsWith(date, '2015-') }

--- a/src/rules-parser.pegjs
+++ b/src/rules-parser.pegjs
@@ -208,7 +208,10 @@ Method "method" = name:Identifier params:ParameterList _ body:FunctionBody {
 }
 
 FunctionBody = "{" _ ("return" _)? exp:Expression _ ";"? _ "}" _ { return exp; }
-  / "=" _ exp:Expression _ ";" _ { return exp; }
+  / "=" _ exp:Expression _ ";" _ {
+    warn("Use of fn(x) = exp; format is deprecated; use fn(x) { exp }, instead.")
+    return exp;
+  }
 
 ParameterList = "(" list:IdentifierList ")" _ { return ensureLowerCase(list, "Function arguments"); }
 

--- a/src/test/generator-test.ts
+++ b/src/test/generator-test.ts
@@ -285,7 +285,7 @@ suite("Rules Generator Tests", function() {
         expect: {'.validate': "newData.hasChildren()",
                  x: {'$key1': {'.validate': "newData.isNumber()"}},
                  '$other': {'.validate': "false"}} },
-      { data: "type SmallString extends String { validate() = this.length < 32; } " +
+      { data: "type SmallString extends String { validate() { this.length < 32 } } " +
               "type T {x: Map<SmallString, Number>}",
         expect: {'.validate': "newData.hasChildren()",
                  x: {'$key1': {'.validate': "$key1.length < 32 && newData.isNumber()"}},
@@ -300,12 +300,12 @@ suite("Rules Generator Tests", function() {
                  'second': {'.validate': "newData.isNumber()"},
                  '$other': {'.validate': "false"}} },
 
-      { data: "type X { a: Number, validate() = this.a == key(); } type T extends X[];",
+      { data: "type X { a: Number, validate() { this.a == key() } } type T extends X[];",
         expect: {'$key1': {'.validate': "newData.hasChildren(['a']) && newData.child('a').val() == $key1",
                            'a': {'.validate': "newData.isNumber()"},
                            '$other': {'.validate': "false"}}
                 } },
-      { data: "type X { a: Number, validate() = this.a == key(); } type T { x: X }",
+      { data: "type X { a: Number, validate() { this.a == key() } } type T { x: X }",
         expect: {'x': {'.validate': "newData.hasChildren(['a']) && newData.child('a').val() == 'x'",
                        'a': {'.validate': "newData.isNumber()"},
                        '$other': {'.validate': "false"}},
@@ -313,8 +313,8 @@ suite("Rules Generator Tests", function() {
                  '.validate': "newData.hasChildren(['x'])"
                 } },
 
-      { data: "type T extends String { validate() = root == 'new' && prior(root) == 'old';}" +
-              "path /t/x is Any { read() = root == 'old';}",
+      { data: "type T extends String { validate() { root == 'new' && prior(root) == 'old' } }" +
+              "path /t/x is Any { read() { root == 'old' } }",
         expect: {'.validate': "newData.isString() && newData.parent().val() == 'new' && root.val() == 'old'",
                  'x': {'.read': "root.val() == 'old'"}
                 } },

--- a/src/test/parser-test.ts
+++ b/src/test/parser-test.ts
@@ -202,11 +202,11 @@ suite("Rules Parser Tests", function() {
         expect: [{ isType: ast.typeType('Any'),
                    template: new ast.PathTemplate(['p', new ast.PathPart('$q', 'q')]),
                    methods: {write: {params: [], body: ast.boolean(true)}}}] },
-      { data: "path /x/y { read() = true; }",
+      { data: "path /x/y { read() { true } }",
         expect: [{ isType: ast.typeType('Any'),
                    template: new ast.PathTemplate(['x', 'y']),
                    methods: {read: {params: [], body: ast.boolean(true)}}}] },
-      { data: "path /x { read() = true; /y { write() = true; }}",
+      { data: "path /x { read() { true } /y { write() { true } }}",
         expect: [{ isType: ast.typeType('Any'),
                    template: new ast.PathTemplate(['x']),
                    methods: {read: {params: [], body: ast.boolean(true)}}},
@@ -214,7 +214,7 @@ suite("Rules Parser Tests", function() {
                    template: new ast.PathTemplate(['x', 'y']),
                    methods: {write: {params: [], body: ast.boolean(true)}}}] },
 
-      { data: "path /x { read() = true; /y { write() = true; path /{$id} { validate() = false; }}}",
+      { data: "path /x { read() { true } /y { write() { true } path /{$id} { validate() { false } }}}",
         expect: [{ isType: ast.typeType('Any'),
                    template: new ast.PathTemplate(['x']),
                    methods: {read: {params: [], body: ast.boolean(true)}}},
@@ -362,7 +362,6 @@ suite("Rules Parser Tests", function() {
       "function f(x) { return x + 1 }",
       "function f(x) { x + 1; }",
       "function f(x) { x + 1 }",
-      "f(x) = x + 1;",
     ];
 
     helper.dataDrivenTest(tests, function(data, expect) {
@@ -378,7 +377,6 @@ suite("Rules Parser Tests", function() {
       "validate() { return this  }",
       "validate() { this; }",
       "validate() { this }",
-      "validate() = this;",
     ];
 
     helper.dataDrivenTest(tests, function(data, expect) {
@@ -402,7 +400,7 @@ suite("Rules Parser Tests", function() {
       "/p/{c} { validate() { return true; } }",
       "/p/{c} { validate() { return true } }",
       "/p/{c} { validate() { true } }",
-      "/p/{c} { validate() = true; }",
+      "/p/{c} { validate() { true; } }",
     ];
 
     helper.dataDrivenTest(tests, function(data, expect) {
@@ -461,8 +459,6 @@ suite("Rules Parser Tests", function() {
     ];
 
     helper.dataDrivenTest(tests, function(data, expect) {
-      logger.reset();
-      logger.silent();
       try {
         parse(data);
       } catch (e) {
@@ -473,15 +469,15 @@ suite("Rules Parser Tests", function() {
     });
   });
 
-  suite("Deprecation errors.", function() {
+  suite("Deprecation warnings.", function() {
     var tests = [
       { data: "path /x/$y is String;",
         expect: /path segment is deprecated/ },
+      { data: "f(x) = x + 1;",
+        expect: /fn\(x\) = exp; format is deprecated/ },
     ];
 
     helper.dataDrivenTest(tests, function(data, expect) {
-      logger.reset();
-      logger.silent();
       parse(data);
       assert.match(logger.getLastMessage(), expect);
     });

--- a/src/test/test-helper.ts
+++ b/src/test/test-helper.ts
@@ -17,6 +17,7 @@
 
 import util = require('../util');
 import ast = require('../ast');
+import logger = require('../logger');
 
 /*
  * Run data drive test with tests is one of these formats:
@@ -62,6 +63,10 @@ export function dataDrivenTest(tests, testIt, formatter?) {
       }
     }
 
+    setup(() => {
+      logger.reset();
+      logger.silent();
+    });
     test(label, testIt.bind(undefined, data, expect, tests[i]));
   }
 }


### PR DESCRIPTION
@TristonianJones REVIEW ONLY (DO NOT MERGE - based on non-master branch)

Deprecate fn(x) = exp; style of function definition (with a warning, for now).