### PR TITLE
Improve parsing errors to be more specific.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,0 +1,1 @@
+fixed - Parse errors are more granular - reporting the source of the error line rather than just failing a whole type or path statement.

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -45,7 +45,12 @@ export function setContext(fn: () => ErrorContext) {
 }
 
 export function error(s: string) {
-  lastMessage = errorString(s);
+  let err = errorString(s);
+  // De-dup identical messages
+  if (err  === lastMessage) {
+    return;
+  }
+  lastMessage = err;
   lastError = lastMessage;
   if (!silenceOutput) {
     console.error(lastError);
@@ -54,7 +59,12 @@ export function error(s: string) {
 }
 
 export function warn(s: string) {
-  lastMessage = errorString(s);
+  let err = errorString(s);
+  // De-dup identical messages
+  if (err === lastMessage) {
+    return;
+  }
+  lastMessage = err;
   if (!silenceOutput) {
     console.warn(lastMessage);
   }

--- a/src/test/parser-test.ts
+++ b/src/test/parser-test.ts
@@ -459,6 +459,14 @@ suite("Rules Parser Tests", function() {
         expect: /missing path template/i },
       { data: "path / }",
         expect: /missing body of path/i },
+      { data: "function foo { 7 }",
+        expect: /missing parameters/i },
+      { data: "foo { 7 }",
+        expect: /expected.*function/i },
+      { data: "foo(x)",
+        expect: /missing.*body/i },
+      { data: "path /x { foo(x) }",
+        expect: /missing.*body/i },
     ];
 
     helper.dataDrivenTest(tests, function(data, expect) {
@@ -477,6 +485,8 @@ suite("Rules Parser Tests", function() {
       { data: "path /x/$y is String;",
         expect: /path segment is deprecated/ },
       { data: "f(x) = x + 1;",
+        expect: /fn\(x\) = exp; format is deprecated/ },
+      { data: "f(x) = x + 1",
         expect: /fn\(x\) = exp; format is deprecated/ },
     ];
 

--- a/src/test/parser-test.ts
+++ b/src/test/parser-test.ts
@@ -28,7 +28,6 @@ import bolt = require('../bolt');
 import helper = require('./test-helper');
 
 // TODO: Test duplicated function, and schema definitions.
-// TODO: Test other parser errors - appropriate messages (exceptions).
 
 suite("Rules Parser Tests", function() {
   test("Empty input", function() {
@@ -456,6 +455,10 @@ suite("Rules Parser Tests", function() {
         expect: /./ },
       { data: "path /x { validate() { return this.test(/a/g); } }",
         expect: /unsupported regexp modifier/i },
+      { data: "path {}",
+        expect: /missing path template/i },
+      { data: "path / }",
+        expect: /missing body of path/i },
     ];
 
     helper.dataDrivenTest(tests, function(data, expect) {

--- a/src/test/parser-test.ts
+++ b/src/test/parser-test.ts
@@ -465,8 +465,14 @@ suite("Rules Parser Tests", function() {
         expect: /expected.*function/i },
       { data: "foo(x)",
         expect: /missing.*body/i },
-      { data: "path /x { foo(x) }",
-        expect: /missing.*body/i },
+      { data: "path /x { foo(x); }",
+        expect: /invalid path or method/i },
+      { data: "foo(x) { x = 'a' }",
+        expect: /equality/i },
+      { data: "type X { bad-prop: String; }",
+        expect: /invalid property or method/i },
+      { data: "type { foo: String;}",
+        expect: /missing type name/i },
     ];
 
     helper.dataDrivenTest(tests, function(data, expect) {
@@ -477,6 +483,18 @@ suite("Rules Parser Tests", function() {
         return;
       }
       assert.fail(undefined, undefined, "No exception thrown.");
+    });
+  });
+
+  suite("Syntax warnings.", function() {
+    var tests = [
+      { data: "path /x { read() { true }; }",
+        expect: /extra separator/i },
+    ];
+
+    helper.dataDrivenTest(tests, function(data, expect) {
+      parse(data);
+      assert.match(logger.getLastMessage(), expect);
     });
   });
 


### PR DESCRIPTION
In order to generate more specific errors messages, it's necessary to relax some rules of the PEG grammar, so that we can emit errors at the point of failure, rather than failing a high level construct like a type or path statement.

@tomlarkworthy 