### PR TITLE
Stack traces in tests rewritten to use source-map info

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -157,7 +157,7 @@ gulp.task('browserify-bolt', ['ts-compile'], function() {
 gulp.task('test', ['lint', 'build'], function() {
   mkdirp(TMP_DIR);
   return gulp.src(CI_TESTS.map(testFileSource))
-    .pipe(mocha({ui: 'tdd'}));
+    .pipe(mocha({ui: 'tdd', require: ['source-map-support/register']}));
 });
 
 gulp.task('default', ['test']);

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "merge-stream": "^1.0.0",
     "mkdirp": "^0.5.1",
     "pegjs": "^0.8.0",
-    "source-map-support": "^0.3.2",
+    "source-map-support": "^0.4.0",
     "tslint": "^2.5.0-beta",
     "typescript": "^1.6.2",
     "vinyl-source-stream": "^1.1.0"

--- a/tools/run-tests
+++ b/tools/run-tests
@@ -5,5 +5,5 @@ set -e
 
 cd $PROJ_DIR
 if gulp clean lint build; then
-    mocha lib/test --ui --require source-map-support/register tdd "$@"
+    mocha lib/test --ui tdd --require "source-map-support/register" "$@"
 fi

--- a/tools/run-tests
+++ b/tools/run-tests
@@ -5,5 +5,5 @@ set -e
 
 cd $PROJ_DIR
 if gulp clean lint build; then
-    mocha lib/test --ui tdd "$@"
+    mocha lib/test --ui --require source-map-support/register tdd "$@"
 fi


### PR DESCRIPTION
@mckoss Stack trackes in .ts not .js now :)