### PR TITLE
Mocha grep in gulp

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,7 +15,6 @@
  */
 'use strict';
 
-
 var argv = require('yargs').argv;
 var path = require('path');
 var gulp = require('gulp');

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,6 +15,8 @@
  */
 'use strict';
 
+
+var argv = require('yargs').argv;
 var path = require('path');
 var gulp = require('gulp');
 var source = require('vinyl-source-stream');
@@ -156,8 +158,15 @@ gulp.task('browserify-bolt', ['ts-compile'], function() {
 // Runs the Mocha test suite
 gulp.task('test', ['lint', 'build'], function() {
   mkdirp(TMP_DIR);
+  var mochaOptions = {
+    ui: 'tdd',
+    require: ['source-map-support/register']
+  };
+  if (argv.grep) {
+    mochaOptions['grep'] = argv.grep;
+  }
   return gulp.src(CI_TESTS.map(testFileSource))
-    .pipe(mocha({ui: 'tdd', require: ['source-map-support/register']}));
+    .pipe(mocha(mochaOptions));
 });
 
 gulp.task('default', ['test']);

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "source-map-support": "^0.4.0",
     "tslint": "^2.5.0-beta",
     "typescript": "^1.6.2",
-    "vinyl-source-stream": "^1.1.0"
+    "vinyl-source-stream": "^1.1.0",
+    "yargs": "^3.32.0"
   },
   "dependencies": {
     "chai": "^3.2.0",


### PR DESCRIPTION
Enable mocha's --grep to be used on command line through gulp invocation like `gulp watch --grep "Sample"`
@mckoss 