### PR TITLE
Fix use strict CI error with nesting of function.

### DIFF
--- a/src/rules-generator.ts
+++ b/src/rules-generator.ts
@@ -652,6 +652,13 @@ export class Generator {
       return params[exp2.name] || self.globals[exp2.name] || exp2;
     }
 
+    // Convert ref[prop] => ref.child(prop)
+    function snapshotChild(ref: ast.ExpReference): ast.Exp {
+      return ast.cast(ast.call(ast.reference(ref.base, ast.string('child')),
+                               [ref.accessor]),
+                      'Snapshot');
+    }
+
     switch (exp.type) {
     case 'op':
       let expOp = <ast.ExpOp> ast.copyExp(exp);
@@ -677,13 +684,6 @@ export class Generator {
       return lookupVar(exp);
 
     case 'ref':
-      // Convert ref[prop] => ref.child(prop)
-      function snapshotChild(ref: ast.ExpReference): ast.Exp {
-        return ast.cast(ast.call(ast.reference(ref.base, ast.string('child')),
-                                 [ref.accessor]),
-                        'Snapshot');
-      }
-
       let expRef = <ast.ExpReference> ast.copyExp(exp);
       expRef.base = subExpression(expRef.base);
 


### PR DESCRIPTION
@mikelehen Bolt CI was failing with a 'use strict' error in node 0.10 and 0.12.  Not sure why this only just started showing up - but I move the offending function to the top level instead of nested in a switch-case.
