### PR TITLE
Add strictNullChecks in TS 2.0 and fix errors.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -79,7 +79,11 @@ gulp.task('tslint', function() {
 gulp.task('lint', ['eslint', 'tslint']);
 
 gulp.task('ts-compile', ['build-peg'], function() {
-  var tsProject = ts.createProject('tsconfig.json');
+  var tsProject = ts.createProject('tsconfig.json', {
+    // Use the repo-installed version of typescript instead of
+    // the version built into gulp-typescript.
+    typescript: require('typescript')
+  });
   return tsProject.src()
       .pipe(sourcemaps.init())
       .pipe(ts(tsProject))

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "pegjs": "^0.8.0",
     "source-map-support": "^0.4.0",
     "tslint": "^2.5.0-beta",
-    "typescript": "^1.6.2",
+    "typescript": "^2.0.0",
     "typings": "^1.3.2",
     "vinyl-source-stream": "^1.1.0",
     "yargs": "^3.32.0"

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -112,7 +112,7 @@ export class PathPart {
       label = '$' + label;
     }
     this.label = label;
-    this.variable = variable;
+    this.variable = <string> variable;
   }
 }
 
@@ -186,7 +186,7 @@ export interface Path {
   methods: { [name: string]: Method };
 };
 
-export interface Schema {
+export class Schema {
   derivedFrom: ExpType;
   properties: TypeParams;
   methods: { [name: string]: Method };
@@ -194,6 +194,10 @@ export interface Schema {
   // Generic parameters - if a Generic schema
   params?: string[];
   getValidator?: (params: Exp[]) => Object;
+
+  static isGeneric(schema: Schema): boolean {
+    return schema.params !== undefined && schema.params.length > 0;
+  }
 };
 
 export var string: (v: string) => ExpValue = valueGen('String');
@@ -629,7 +633,8 @@ export function decodeExpression(exp: Exp, outerPrecedence?: number): string {
     outerPrecedence = 0;
   }
   var innerPrecedence = precedenceOf(exp);
-  var result: string;
+  var result = '';
+
   switch (exp.type) {
   case 'Boolean':
   case 'Number':

--- a/src/file-io.ts
+++ b/src/file-io.ts
@@ -16,6 +16,9 @@
 import * as fs from 'fs';
 import * as util from './util';
 
+const hasXMLHttpRequest =
+  typeof global !== 'undefined' && (<any> global)['XMLHttpRequest'] !== undefined;
+
 export interface ReadFileResult {
   content: string;
   url: string;
@@ -39,18 +42,14 @@ export function writeJSONFile(path: string, data: any): Promise<ReadFileResult> 
 }
 
 export function readFile(path: string): Promise<ReadFileResult> {
-  return request('GET', path) || readFS(path);
+  return hasXMLHttpRequest ? request('GET', path) : readFS(path);
 }
 
 export function writeFile(path: string, data: any): Promise<ReadFileResult> {
-  return request('PUT', path, data) || writeFS(path, data);
+  return hasXMLHttpRequest ? request('PUT', path, data) : writeFS(path, data);
 }
 
 function request(method: string, url: string, data?: any): Promise<ReadFileResult> {
-  if (!(<any> global).XMLHttpRequest) {
-    return undefined;
-  }
-
   return new Promise(function(resolve, reject) {
     let req = new XMLHttpRequest();
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-let lastError: string;
-let lastMessage: string;
+let lastError: string | undefined;
+let lastMessage: string | undefined;
 let errorCount: number;
 let silenceOutput: boolean;
 
@@ -68,7 +68,7 @@ export function warn(s: string) {
   }
 }
 
-export function getLastMessage(): string {
+export function getLastMessage(): string | undefined {
   return lastMessage;
 }
 
@@ -87,7 +87,7 @@ export function hasErrors(): boolean {
 
 export function errorSummary(): string {
   if (errorCount === 1) {
-    return lastError;
+    return <string> lastError;
   }
 
   if (errorCount !== 0) {

--- a/src/simulator.ts
+++ b/src/simulator.ts
@@ -152,7 +152,7 @@ class RulesSuite {
     this.databaseReady();
   }
 
-  uid(username: string): string {
+  uid(username: string): string | undefined {
     return this.ensureUser(username).uid;
   }
 
@@ -182,9 +182,9 @@ export class RulesTest {
   private lastError: string;
   private steps: Step[] = [];
   private failed = false;
-  private path: string;
+  private path: string | undefined;
   private client: rest.Client;
-  private status: boolean;
+  private status: boolean | undefined;
 
   constructor(private testName: string,
               private suite: RulesSuite,
@@ -265,7 +265,7 @@ export class RulesTest {
     return this;
   }
 
-  at(opPath: string): RulesTest {
+  at(opPath: string | undefined): RulesTest {
     this.queue('at', arguments, () => {
       this.path = opPath;
       return Promise.resolve();
@@ -275,6 +275,9 @@ export class RulesTest {
 
   write(obj: any): RulesTest {
     this.queue('write', arguments, () => {
+      if (this.path === undefined) {
+        return Promise.reject(new Error("Use at() function to set path to write."));
+      }
       return this.client.put(this.path, obj)
         .then(() => {
           this.status = true;
@@ -289,6 +292,9 @@ export class RulesTest {
 
   push(obj: any): RulesTest {
     this.queue('write', arguments, () => {
+      if (this.path === undefined) {
+        return Promise.reject(new Error("Use at() function to set path to push."));
+      }
       let path = this.path;
       if (path.slice(-1)[0] !== '/') {
         path += '/';
@@ -308,6 +314,9 @@ export class RulesTest {
 
   read(): RulesTest {
     this.queue('read', arguments, () => {
+      if (this.path === undefined) {
+        return Promise.reject(new Error("Use at() function to set path to read."));
+      }
       return this.client.get(this.path)
         .then(() => {
           this.status = true;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "rootDir": "src",
     "module": "commonjs",
     "noImplicitAny": true,
+    "strictNullChecks": true,
     "preserveConstEnums": true,
     "inlineSourceMap": true,
     "noEmitOnError": true


### PR DESCRIPTION
Upgraded to TypeScript 2.0 so I could add strictNullChecks compiler option.  This PR fixes the resulting errors or explicit type modifications needed to get a clean build.