### PR TITLE
Enable generating .read/.write false rules for case where property is sibling of wildcard.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,2 +1,3 @@
-fixed - Issue #118 Fix validation of Array, Map, and Null types (and their unions).
+fixed - Issue #97 .read/.write false not generated when siblings of wildcard children.
+fixed - Issue #118 Validation of Array, Map, and Null types (and their unions) incorrect.
 fixed - Issue #111 Use of Any generating incorrect rules.

--- a/samples/issue-97.bolt
+++ b/samples/issue-97.bolt
@@ -1,0 +1,11 @@
+path /parent {
+  read() { auth !== null }
+
+  /someKey {
+    write() { false }
+  }
+
+  /{all_other_keys} {
+    write() { auth !== null }
+  }
+}

--- a/samples/issue-97.json
+++ b/samples/issue-97.json
@@ -1,0 +1,13 @@
+{
+  "rules": {
+    "parent": {
+      "someKey": {
+        ".write": "false"
+      },
+      "$all_other_keys": {
+        ".write": "auth != null"
+      },
+      ".read": "auth != null"
+    }
+  }
+}

--- a/samples/issue-97.json
+++ b/samples/issue-97.json
@@ -2,6 +2,7 @@
   "rules": {
     "parent": {
       "someKey": {
+        ".validate": "true",
         ".write": "false"
       },
       "$all_other_keys": {

--- a/src/rules-generator.ts
+++ b/src/rules-generator.ts
@@ -596,7 +596,7 @@ export class Generator {
                                             methodThisIs[prop],
                                             scope,
                                             path);
-        // Remove no-op .read or .write rule if not sibling wildcard props.
+        // Remove no-op .read or .write rule if no sibling wildcard props.
         if ((prop === '.read' || prop === '.write') && result === 'false') {
           if (!hasWildcardSibling(path)) {
             return undefined;

--- a/src/test/sample-files.ts
+++ b/src/test/sample-files.ts
@@ -10,6 +10,7 @@ export let samples = [
   "issue-111",
   "issue-118",
   "issue-136",
+  "issue-97",
   "mail",
   "map-scalar",
   "multi-update",


### PR DESCRIPTION
Even though these rules are "no-ops", they are sometimes needed since the rule from a sibling wildcard is not default.

Fixes Issue #97.