### PR TITLE
Fix bug expanding type expression too early - Issue #169.

### DIFF
--- a/bin/firebase-bolt
+++ b/bin/firebase-bolt
@@ -23,16 +23,19 @@ var parseArgs = require('minimist');
 var util = require('../lib/util');
 var bolt = require('../lib/bolt');
 var pkg = require('../package.json');
+var logger = require('../lib/logger');
 
 var VERSION_STRING = "Firebase Bolt v" + pkg.version;
+var DEBUG = false;
 
 var opts = {
-  boolean: ['version', 'help'],
+  boolean: ['version', 'help', 'debug'],
   string: ['output'],
   alias: {
     'v': 'version',
     'h': 'help',
     'o': 'output',
+    'd': 'debug'
   },
   unknown: function(flag) {
     if (flag[0] == '-') {
@@ -54,6 +57,11 @@ function main() {
   if (args.version) {
     console.log(VERSION_STRING);
     return;
+  }
+
+  if (args.debug) {
+    DEBUG = true;
+    logger.setDebug();
   }
 
   if (args.help) {
@@ -128,6 +136,7 @@ function usage(code) {
     ["-h --help", "Display this helpful message."],
     ["-o --output file", "Output to file.json."],
     ["-v --version", "Display Firebase Bolt version."],
+    ["-d --debug", "Display additional debugging information."],
     []
   ]).join('\n'));
 
@@ -156,6 +165,9 @@ function translateRules(input) {
   try {
     symbols = bolt.parse(input);
   } catch (e) {
+    if (DEBUG) {
+      log(e.stack);
+    }
     log(e.message, e.line, e.column);
     process.exit(1);
   }
@@ -164,6 +176,9 @@ function translateRules(input) {
     var gen = new bolt.Generator(symbols);
     rules = gen.generateRules();
   } catch (e) {
+    if (DEBUG) {
+      log(e.stack);
+    }
     log(e.message);
     process.exit(2);
   }

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,0 +1,1 @@
+fixed - Issue #169 Did not allow prior() function in type validation.

--- a/samples/issue-169.bolt
+++ b/samples/issue-169.bolt
@@ -1,0 +1,5 @@
+path /test is Map<Test, String> {}
+
+type Test extends String {
+  validate() { prior(root) != null }
+}

--- a/samples/issue-169.json
+++ b/samples/issue-169.json
@@ -1,0 +1,10 @@
+{
+  "rules": {
+    "test": {
+      "$key1": {
+        ".validate": "root.val() != null && newData.isString()"
+      },
+      ".validate": "newData.hasChildren()"
+    }
+  }
+}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -18,6 +18,8 @@ let lastMessage: string | undefined;
 let errorCount: number;
 let silenceOutput: boolean;
 
+let DEBUG = false;
+
 let getContext = () => (<ErrorContext> {});
 
 reset();
@@ -27,6 +29,10 @@ export function reset() {
   lastMessage = undefined;
   errorCount = 0;
   silenceOutput = false;
+}
+
+export function setDebug(debug = true) {
+  DEBUG = debug;
 }
 
 export function silent(f = true) {
@@ -52,6 +58,10 @@ export function error(s: string) {
   lastError = lastMessage;
   if (!silenceOutput) {
     console.error(lastError);
+    if (DEBUG) {
+      let e = new Error("Stack trace");
+      console.error(e.stack);
+    }
   }
   errorCount += 1;
 }

--- a/src/rules-generator.ts
+++ b/src/rules-generator.ts
@@ -288,7 +288,11 @@ export class Generator {
     var key = ast.decodeExpression(type);
     if (!this.validators[key]) {
       this.validators[key] = {'.validate': ast.literal('***TYPE RECURSION***') };
+
+      let allowSave = this.allowUndefinedFunctions;
+      this.allowUndefinedFunctions = true;
       this.validators[key] = this.createValidator(type);
+      this.allowUndefinedFunctions = allowSave;
     }
     return this.validators[key];
   }
@@ -801,7 +805,7 @@ export class Generator {
       if (!this.allowUndefinedFunctions) {
         var funcName = ast.getMethodName(expCall);
         if (funcName !== '' && !(funcName in this.symbols.schema['String'].methods ||
-              util.arrayIncludes(snapshotMethods, funcName))) {
+                                 util.arrayIncludes(snapshotMethods, funcName))) {
           this.fatal(errors.undefinedFunction + ast.decodeExpression(expCall.ref));
         }
       }

--- a/src/test/sample-files.ts
+++ b/src/test/sample-files.ts
@@ -10,6 +10,7 @@ export let samples = [
   "issue-111",
   "issue-118",
   "issue-136",
+  "issue-169",
   "issue-97",
   "mail",
   "map-scalar",


### PR DESCRIPTION
Fix for Issue #169.

We were expanding functions earlier than necessary - now deferred to when the validation rules are generated (not in the middle of expanding schema/type definitions).

This PR also adds a --debug flag to aid in debugging issues like this in the future.