### PR TITLE
Added version number to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firebase-bolt",
   "description": "Firebase Bolt Security and Modeling Language Compiler",
-  "version": "0.0.0",
+  "version": "0.8.2",
   "author": "Firebase (https://firebase.google.com/)",
   "main": "lib/bolt.js",
   "homepage": "https://github.com/firebase/bolt",


### PR DESCRIPTION
### Description

Catapult (the internal tool we use to release Firebase JavaScript libraries) now works without the `0.0.0` version placeholder in the `package.json` file. So, we can finally add the actual version numbers back into this file.

### Code sample

N/A