### PR TITLE
Update Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 [![NPM Version](https://badge.fury.io/js/firebase-bolt.svg)](https://npmjs.org/package/firebase-bolt)
 [![NPM Downloads](http://img.shields.io/npm/dm/firebase-bolt.svg)](https://npmjs.org/package/firebase-bolt)
 
-Bolt is an experimental security and rules compiler for Firebase.  It is currently
-in beta.  The language definition is converging, but not yet finalized.  We welcome
+Bolt is an experimental security and rules compiler for Firebase Realtime Database (not for Firebase Cloud Storage). 
+It is currently in beta.  The language definition is converging, but not yet finalized.  We welcome
 experimentation, but ask that you hand-verify the resulting JSON output before
 using with production applications.
 
@@ -28,8 +28,9 @@ Execute the Bolt compiler from the command line:
 
     $ firebase-bolt rules.bolt
 
-Will create a rules.json which you can then upload via the [firebase command
-line](https://www.firebase.com/docs/hosting/command-line-tool.html):
+Will create a rules.json which you can then upload via the [Firebase Web Console](https://console.firebase.google.com/)
+or the [Firebase command
+line](https://firebase.google.com/docs/cli):
 
     $ firebase deploy
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -27,8 +27,8 @@ When you first create a Firebase app, you get a default rule set that allows all
 and write all Realtime Database data. In Bolt, these default permissions can be written as:
 ```javascript
 path / {
-  read() { true }
-  write() { true }
+  read() { auth != null }
+  write() { auth != null }
 }
 ```
 During the early stages of testing, many developers may open database access to unauthenticated requests. This makes it easy to test your code, but is unsafe for production apps since anyone can read and overwrite any data saved by your app. In Bolt, these open-access permissions can be written as: 


### PR DESCRIPTION
Change links to point to the new Google FIrebase Docs site (https://firebase.google.com/docs/).  Also clarified that Bolt only work on the Firebase Realtime Database, not Cloud Storage.