### PR TITLE
Type imports

### DIFF
--- a/bin/firebase-bolt
+++ b/bin/firebase-bolt
@@ -116,7 +116,7 @@ function main() {
 * ability to write the translation from STDIN not just the file system.
 * ??? Global modules should still be supported from std in.
 */
-function writeTranslation(outFile, data, inFile) {
+function writeTranslation(outFile, data) {
   fs.writeFile(outFile, translateRules(data) + '\n', 'utf8', function(err2) {
     if (err2) {
       log("Could not write file: " + outFile);
@@ -191,7 +191,7 @@ function translateRulesWithImports(inFile) {
   var symbols;
 
   try {
-    symbols = bolt.parse(inFile);
+    symbols = bolt.parseWithImports(inFile);
     return continueTranslateRules(symbols);
   } catch (e) {
     if (DEBUG) {

--- a/bin/firebase-bolt
+++ b/bin/firebase-bolt
@@ -82,6 +82,8 @@ function main() {
       if (args.output !== undefined) {
         writeTranslation(util.ensureExtension(args.output, 'json'), data);
       } else {
+        // Note: Not sure but this will more than likely break some form of
+        // compatability
         console.log(translateRules(data));
       }
     });
@@ -106,13 +108,25 @@ function main() {
       log("Could not read file: " + inFile);
       process.exit(1);
     }
-    writeTranslation(outFile, data);
+    writeTranslationWithImports(outFile, data, inFile);
+  });
+}
+/**
+* Depricated: Use writeTranslation still needs to be maintained as we have the
+* ability to write the translation from STDIN not just the file system.
+* ??? Global modules should still be supported from std in.
+*/
+function writeTranslation(outFile, data, inFile) {
+  fs.writeFile(outFile, translateRules(data) + '\n', 'utf8', function(err2) {
+    if (err2) {
+      log("Could not write file: " + outFile);
+      process.exit(1);
+    }
   });
 }
 
-function writeTranslation(outFile, data) {
-  log("Generating " + outFile + "...");
-  fs.writeFile(outFile, translateRules(data) + '\n', 'utf8', function(err2) {
+function writeTranslationWithImports(outFile, data, inFile) {
+  fs.writeFile(outFile, translateRulesWithImports(inFile) + '\n', 'utf8', function(err2) {
     if (err2) {
       log("Could not write file: " + outFile);
       process.exit(1);
@@ -158,12 +172,12 @@ function readFile(f, callback) {
   });
 }
 
-function translateRules(input) {
+function translateRules(input){
   var symbols;
-  var rules;
 
   try {
     symbols = bolt.parse(input);
+    return continueTranslateRules(symbols);
   } catch (e) {
     if (DEBUG) {
       log(e.stack);
@@ -171,7 +185,24 @@ function translateRules(input) {
     log(e.message, e.line, e.column);
     process.exit(1);
   }
+}
 
+function translateRulesWithImports(inFile) {
+  var symbols;
+
+  try {
+    symbols = bolt.parse(inFile);
+    return continueTranslateRules(symbols);
+  } catch (e) {
+    if (DEBUG) {
+      log(e.stack);
+    }
+    log(e.message, e.line, e.column);
+    process.exit(1);
+  }
+}
+function continueTranslateRules(symbols){
+  var rules;
   try {
     var gen = new bolt.Generator(symbols);
     rules = gen.generateRules();

--- a/bin/firebase-bolt
+++ b/bin/firebase-bolt
@@ -172,7 +172,7 @@ function readFile(f, callback) {
   });
 }
 
-function translateRules(input){
+function translateRules(input) {
   var symbols;
 
   try {
@@ -201,7 +201,7 @@ function translateRulesWithImports(inFile) {
     process.exit(1);
   }
 }
-function continueTranslateRules(symbols){
+function continueTranslateRules(symbols) {
   var rules;
   try {
     var gen = new bolt.Generator(symbols);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -91,7 +91,7 @@ gulp.task('ts-compile', ['build-peg'], function() {
       .pipe(gulp.dest(LIB_DIR));
 });
 
-gulp.task('build', ['ts-compile', 'browserify-bolt']);
+gulp.task('build', ['build-peg', 'ts-compile', 'browserify-bolt']);
 
 gulp.task('build-peg', function() {
   return gulp.src('src/rules-parser.pegjs')

--- a/samples/subModule/typeOne.bolt
+++ b/samples/subModule/typeOne.bolt
@@ -1,0 +1,25 @@
+import {TypeTwo} from './typeTwo'
+
+
+type SampleOne extends TypeTwo {
+	validate() { true }
+}
+type TypeOne extends String {
+	validate() { true }
+}
+type Alpha extends String {
+  validate() { this.test(/^[a-zA-Z]*$/) }
+}
+
+type Alphanumeric {
+  validate() { this.test(/^[a-zA-Z0-9]*$/) }
+	alphaValue: String
+}
+
+type Ascii extends String {
+  validate() { this.test(/^[\x00-\x7F]+$/) }
+}
+
+type Secondary extends String {
+   validate() { true }
+}

--- a/samples/subModule/typeTwo.bolt
+++ b/samples/subModule/typeTwo.bolt
@@ -1,0 +1,8 @@
+
+type TypeTwo extends String {
+  validate() { this.test(/^[a-z]*$/) }
+}
+
+type Fourth extends String {
+  validate() { this.test(/^4$/)}
+}

--- a/samples/type-imports.bolt
+++ b/samples/type-imports.bolt
@@ -1,0 +1,40 @@
+// Lvl 1 - simply import everything.
+import * from './subModule/typeOne'
+// Lvl 2 - import single item only
+import {Alpha, Alphanumeric} from './subModule/typeOne'
+// Lvl 3 - import as an aliased type
+import {Alpha, Alphanumeric} as types from './subModule/typeOne'
+// Lvl 4 - import recursive types
+import { SampleOne } from './subModule/typeOne'
+
+// Lvl 5 - import with an adjusted path
+// import from './subModule/typeOne' at '/somewhere' // duplicate import test
+
+
+type Test extends Another {
+  validate() { this.test(/^[0-9]*$/) }
+}
+
+type Another {
+  validate() { this.message.length < 14 }
+  something : String
+}
+path / is SampleOne {
+ validate() { true }
+}
+
+path /test is Alphanumeric {
+  read() {true}
+}
+
+path /alpha is Alpha {
+  read() {true}
+}
+
+path /alphanumeric is types.Alphanumeric {
+  read() { true }
+}
+
+path /ascii is Ascii {
+  read() { true }
+}

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -79,6 +79,7 @@ export interface TypeParams { [name: string]: ExpType; };
 // Simple Type (reference)
 export interface ExpSimpleType extends Exp {
   name: string;
+  namespace?: string;
 }
 
 // Union Type: Type1 | Type2 | ...
@@ -95,6 +96,13 @@ export interface ExpGenericType extends Exp {
 export interface Method {
   params: string[];
   body: Exp;
+}
+
+export interface Import {
+  filename: string;
+  alias: string;
+  identifiers: string[];
+  symbols?: Symbols;
 }
 
 export class PathPart {
@@ -500,6 +508,9 @@ export function method(params: string[], body: Exp): Method {
     body: body
   };
 }
+export function typeTypeNamespaced(typeName: string, namespace: string){
+  return { type: "type", valueType: "type", name: typeName, namespace: namespace};
+}
 
 export function typeType(typeName: string): ExpSimpleType {
   return { type: "type", valueType: "type", name: typeName };
@@ -509,6 +520,9 @@ export function unionType(types: ExpType[]): ExpUnionType {
   return { type: "union", valueType: "type", types: types };
 }
 
+export function genericTypeNamespaced(typeName: string, params: ExpType[], namespace: string) {
+  return { type: "generic", valueType: "type", name: typeName, params: params, namespace: namespace };
+}
 export function genericType(typeName: string, params: ExpType[]): ExpGenericType {
   return { type: "generic", valueType: "type", name: typeName, params: params };
 }
@@ -517,11 +531,13 @@ export class Symbols {
   functions: { [name: string]: Method };
   paths: Path[];
   schema: { [name: string]: Schema };
+  imports: Import[] ;
 
   constructor() {
     this.functions = {};
     this.paths = [];
     this.schema = {};
+    this.imports = [];
   }
 
   register<T>(map: {[name: string]: T}, typeName: string, name: string, object: T): T {
@@ -536,6 +552,16 @@ export class Symbols {
   registerFunction(name: string, params: string[], body: Exp): Method {
     return this.register<Method>(this.functions, 'functions', name,
                                  method(params, body));
+  }
+
+  registerImport(identifiers: string[], alias: string, filePath: string): Import {
+    var i: Import = {
+      filename : filePath,
+      alias: alias,
+      identifiers: identifiers
+    };
+    this.imports.push(i);
+    return i;
   }
 
   registerPath(template: PathTemplate, isType: ExpType | void, methods: { [name: string]: Method; } = {}): Path {

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -508,7 +508,7 @@ export function method(params: string[], body: Exp): Method {
     body: body
   };
 }
-export function typeTypeNamespaced(typeName: string, namespace: string){
+export function typeTypeNamespaced(typeName: string, namespace: string) {
   return { type: "type", valueType: "type", name: typeName, namespace: namespace};
 }
 

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -508,8 +508,13 @@ export function method(params: string[], body: Exp): Method {
     body: body
   };
 }
+
 export function typeTypeNamespaced(typeName: string, namespace: string) {
-  return { type: "type", valueType: "type", name: typeName, namespace: namespace};
+  if (namespace) {
+    return { type: "type", valueType: "type", name: typeName, namespace: namespace};
+  } else {
+    return { type: "type", valueType: "type", name: typeName}; // backwards compatability for tests
+  }
 }
 
 export function typeType(typeName: string): ExpSimpleType {

--- a/src/bolt.ts
+++ b/src/bolt.ts
@@ -19,14 +19,14 @@ if (typeof Promise === 'undefined') {
   require('es6-promise').polyfill();
 }
 
-let parser = require('./rules-parser');
+let parser = require('./imports-parser');
 import * as generator from './rules-generator';
 import * as astImport from './ast';
 
 export let FILE_EXTENSION = 'bolt';
 
 export let ast = astImport;
-export let parse = parser.parse;
+export let parse = parser.parseWithImports;
 export let Generator = generator.Generator;
 export let decodeExpression = ast.decodeExpression;
 export let generate = generator.generate;

--- a/src/bolt.ts
+++ b/src/bolt.ts
@@ -20,13 +20,15 @@ if (typeof Promise === 'undefined') {
 }
 
 let parser = require('./imports-parser');
+let rulesParser = require('./rules-parser');
 import * as generator from './rules-generator';
 import * as astImport from './ast';
 
 export let FILE_EXTENSION = 'bolt';
 
 export let ast = astImport;
-export let parse = parser.parseWithImports;
+export let parseWithImports = parser.parseWithImports;
+export let parse = rulesParser.parse;
 export let Generator = generator.Generator;
 export let decodeExpression = ast.decodeExpression;
 export let generate = generator.generate;

--- a/src/imports-parser.ts
+++ b/src/imports-parser.ts
@@ -1,0 +1,69 @@
+let path = require('path');
+let rulesParser = require('./rules-parser');
+let fs = require('fs');
+let id = 0;
+/*
+  Imports file parser for split file systems
+  Note: Using a modified ES6 syntax to include imports
+*/
+export function parseWithImports(filename: string) {
+  let baseSymbols: {
+    functions: any[],
+    schema: any[],
+    paths: any[],
+    imports: any[]
+  } = {
+      functions: [],
+      schema: [],
+      paths: [],
+      imports: []
+    };
+
+  // creating a stream through which each file will pass
+  let contents = fs.readFileSync(filename, "utf8");
+  return parserWrapper(contents, filename);
+}
+
+/*
+  *************************** Function Section ****************************
+*/
+
+/* ******** wrapper for recursive parsing ******* */
+function parserWrapper(data: string, filename: string) {
+  var sym = rulesParser.parse(data);
+
+  // Process any imports in symbol list
+  for (let i = 0; i < sym.imports.length; i++) {
+    let next = sym.imports[i];
+    var nextFilename = getNextFilenameFromContextAndImport(filename, next.filename);
+    let contents = fs.readFileSync(nextFilename, 'utf8');
+    let nextSymbols = parserWrapper(contents, nextFilename);
+    sym.imports[i].symbols = nextSymbols; // add it to the next part of the tree
+  }
+  return sym;
+}; // end function
+
+// Convert absolute filenames to relative
+// Convert relative filenames to include original path
+function getNextFilenameFromContextAndImport(current: string, nextImport: any) {
+  current = current.replace('.bolt', '');
+  nextImport = nextImport.replace('.bolt', '');
+  var currentFn = current.split('/');
+  var nextFn = nextImport.split('/');
+  let result = '';
+  if (nextFn[0] != '.' && nextFn[0] != '..') { // global reference
+    result = './node_modules/' + nextImport + '/index.bolt';
+  } else {
+    // import {./something} -> ['.','something'] -> ''
+    // import {./something/anotherthing} -> ['.','something','anotherthing'] -> something
+    currentFn.pop(); // remove trailing file name and leave only the directory
+    nextFn = currentFn.concat(nextFn);
+    // if file.bolt exists then we have it otherwise return
+    if (fs.existsSync(nextFn.join('/') + '.bolt')) {
+      result = nextFn.join('/') + '.bolt';
+    } else {
+      result = nextFn.join('/') + '/index.bolt';
+    }
+  }
+  return result;
+}

--- a/src/imports-parser.ts
+++ b/src/imports-parser.ts
@@ -1,24 +1,10 @@
-let path = require('path');
 let rulesParser = require('./rules-parser');
 let fs = require('fs');
-let id = 0;
 /*
   Imports file parser for split file systems
   Note: Using a modified ES6 syntax to include imports
 */
 export function parseWithImports(filename: string) {
-  let baseSymbols: {
-    functions: any[],
-    schema: any[],
-    paths: any[],
-    imports: any[]
-  } = {
-      functions: [],
-      schema: [],
-      paths: [],
-      imports: []
-    };
-
   // creating a stream through which each file will pass
   let contents = fs.readFileSync(filename, "utf8");
   return parserWrapper(contents, filename);
@@ -51,7 +37,7 @@ function getNextFilenameFromContextAndImport(current: string, nextImport: any) {
   var currentFn = current.split('/');
   var nextFn = nextImport.split('/');
   let result = '';
-  if (nextFn[0] != '.' && nextFn[0] != '..') { // global reference
+  if (nextFn[0] !== '.' && nextFn[0] !== '..') { // global reference
     result = './node_modules/' + nextImport + '/index.bolt';
   } else {
     // import {./something} -> ['.','something'] -> ''

--- a/src/rules-generator.ts
+++ b/src/rules-generator.ts
@@ -423,17 +423,17 @@ export class Generator {
 
     // imp.alias is the alias to apply to the imports
     // schemaName.namespace is the alias applied to the type
-    if(!schema) {
+    if (!schema) {
       lSymbols.imports
         .sort(function(x, y) {
-          return x.alias ? 1: 0;
+          return x.alias ? 1 : 0;
         }).map( imp => {
-        if(imp.alias == schemaName.namespace) {
-          if(imp.identifiers.indexOf(schemaName.name) >= 0 || imp.identifiers.length == 0) {
+        if (imp.alias === schemaName.namespace) {
+          if (imp.identifiers.indexOf(schemaName.name) >= 0 || imp.identifiers.length === 0) {
             schema = imp.symbols.schema[schemaName.name];
-            if(schema) {
+            if (schema) {
               let derivedValidator = ref.createValidatorFromSchema(schema, imp.symbols);
-              return extendValidator(derivedValidator, this.ensureValidator(schema.derivedFrom,imp.symbols));
+              return extendValidator(derivedValidator, this.ensureValidator(schema.derivedFrom, imp.symbols));
             }
           }
         }
@@ -442,8 +442,8 @@ export class Generator {
 
     // Fall back to generics if it get's to that.
     // Question: Will this break the generic test below?
-    if(!schema) {
-      if(builtinSchemaNames.indexOf(schemaName.name) >=0 ){
+    if (!schema) {
+      if (builtinSchemaNames.indexOf(schemaName.name) >= 0 ) {
         schema = this.symbols.schema[schemaName.name];
       }
     }
@@ -484,7 +484,7 @@ export class Generator {
 
     if (!(schema.derivedFrom.type === 'type' &&
           (<ast.ExpSimpleType> schema.derivedFrom).name === 'Any')) {
-      extendValidator(validator, this.ensureValidator(schema.derivedFrom,lSymbols));
+      extendValidator(validator, this.ensureValidator(schema.derivedFrom, lSymbols));
     }
 
     let requiredProperties = <string[]> [];
@@ -507,7 +507,7 @@ export class Generator {
       if (propName[0] !== '$' && !this.isNullableType(propType)) {
         requiredProperties.push(propName);
       }
-      extendValidator(<Validator> validator[propName], this.ensureValidator(propType,lSymbols));
+      extendValidator(<Validator> validator[propName], this.ensureValidator(propType, lSymbols));
     });
 
     if (wildProperties > 1 || wildProperties === 1 && requiredProperties.length > 0) {
@@ -545,7 +545,7 @@ export class Generator {
     var exp: ast.ExpValue;
     var lSymbols = this.symbols;
 
-    extendValidator(location, this.ensureValidator(path.isType,lSymbols));
+    extendValidator(location, this.ensureValidator(path.isType, lSymbols));
     location['.scope'] = path.template.getScope();
 
     this.extendValidationMethods(location, path.methods);

--- a/src/rules-generator.ts
+++ b/src/rules-generator.ts
@@ -16,8 +16,10 @@
 import * as util from './util';
 import * as ast from './ast';
 import {warn, error} from './logger';
-let parser = require('./rules-parser');
+import { parseWithImports } from './imports-parser';
 import {parseExpression} from './parse-util';
+
+let parser = require('./rules-parser');
 
 var errors = {
   badIndex: "The index function must return a String or an array of Strings.",
@@ -87,7 +89,7 @@ var writeAliases = <{ [method: string]: ast.Exp }> {
 //   json = bolt.generate(bolt-text)
 export function generate(symbols: string | ast.Symbols): Validator {
   if (typeof symbols === 'string') {
-    symbols = parser.parse(symbols);
+    symbols = parser.parse(parseWithImports(symbols));
   }
   var gen = new Generator(<ast.Symbols> symbols);
   return gen.generateRules();
@@ -246,20 +248,21 @@ export class Generator {
   // }
   // Key must derive from String
   getMapValidator(params: ast.Exp[]): Validator {
+    let lSymbols = this.symbols;
     let keyType = <ast.ExpSimpleType> params[0];
     let valueType = <ast.ExpType> params[1];
-    if (keyType.type !== 'type' || !this.symbols.isDerivedFrom(keyType, 'String')) {
+    if (keyType.type !== 'type' || !lSymbols.isDerivedFrom(keyType, 'String')) {
       throw new Error(errors.invalidMapKey + "  (" + ast.decodeExpression(keyType) + " does not)");
     }
 
     let validator = <Validator> {};
     let index = this.uniqueKey();
     validator[index] = <Validator> {};
-    extendValidator(validator, this.ensureValidator(ast.typeType('Object')));
+    extendValidator(validator, this.ensureValidator(ast.typeType('Object'), lSymbols));
 
     // First validate the key (omit terminal String type validation).
     while (keyType.name !== 'String') {
-      let schema = this.symbols.schema[keyType.name];
+      let schema = lSymbols.schema[keyType.name];
       if (schema.methods['validate']) {
         let exp = this.partialEval(schema.methods['validate'].body, {'this': ast.literal(index)});
         extendValidator(<Validator> validator[index], <Validator> {'.validate': [exp]});
@@ -267,7 +270,7 @@ export class Generator {
       keyType = <ast.ExpSimpleType> schema.derivedFrom;
     }
 
-    extendValidator(<Validator> validator[index], this.ensureValidator(valueType));
+    extendValidator(<Validator> validator[index], this.ensureValidator(valueType, lSymbols));
     return validator;
   }
 
@@ -284,29 +287,29 @@ export class Generator {
   }
 
   // Ensure we have a definition for a validator for the given schema.
-  ensureValidator(type: ast.ExpType): Validator {
+  ensureValidator(type: ast.ExpType, lSymbols: ast.Symbols): Validator {
     var key = ast.decodeExpression(type);
     if (!this.validators[key]) {
       this.validators[key] = {'.validate': ast.literal('***TYPE RECURSION***') };
 
       let allowSave = this.allowUndefinedFunctions;
       this.allowUndefinedFunctions = true;
-      this.validators[key] = this.createValidator(type);
+      this.validators[key] = this.createValidator(type, lSymbols);
       this.allowUndefinedFunctions = allowSave;
     }
     return this.validators[key];
   }
 
-  createValidator(type: ast.ExpType): Validator {
+  createValidator(type: ast.ExpType, lSymbols: ast.Symbols): Validator {
     switch (type.type) {
     case 'type':
-      return this.createValidatorFromSchemaName((<ast.ExpSimpleType> type).name);
+      return this.createValidatorFromSchemaNameNamespaced((<ast.ExpSimpleType> type), lSymbols);
 
     case 'union':
       let union = <Validator> {};
       (<ast.ExpUnionType> type).types.forEach((typePart: ast.ExpType) => {
         // Make a copy
-        var singleType = extendValidator({}, this.ensureValidator(typePart));
+        var singleType = extendValidator({}, this.ensureValidator(typePart, lSymbols));
         mapValidator(singleType, ast.andArray);
         extendValidator(union, singleType);
       });
@@ -347,7 +350,7 @@ export class Generator {
 
     // Expand generics and generate validator from schema.
     schema = this.replaceGenericsInSchema(schema, bindings);
-    return this.createValidatorFromSchema(schema);
+    return this.createValidatorFromSchema(schema, this.symbols);
   }
 
   replaceGenericsInSchema(schema: ast.Schema, bindings: ast.TypeParams): ast.Schema {
@@ -414,8 +417,48 @@ export class Generator {
     return expandedMethod;
   }
 
-  createValidatorFromSchemaName(schemaName: string): Validator {
-    var schema = this.symbols.schema[schemaName];
+  createValidatorFromSchemaNameNamespaced(schemaName: ast.ExpSimpleType, lSymbols: ast.Symbols): Validator {
+    var schema = lSymbols.schema[schemaName.name];
+    let ref = this;
+
+    // imp.alias is the alias to apply to the imports
+    // schemaName.namespace is the alias applied to the type
+    if(!schema) {
+      lSymbols.imports
+        .sort(function(x, y) {
+          return x.alias ? 1: 0;
+        }).map( imp => {
+        if(imp.alias == schemaName.namespace) {
+          if(imp.identifiers.indexOf(schemaName.name) >= 0 || imp.identifiers.length == 0) {
+            schema = imp.symbols.schema[schemaName.name];
+            if(schema) {
+              let derivedValidator = ref.createValidatorFromSchema(schema, imp.symbols);
+              return extendValidator(derivedValidator, this.ensureValidator(schema.derivedFrom,imp.symbols));
+            }
+          }
+        }
+      });
+    }
+
+    // Fall back to generics if it get's to that.
+    // Question: Will this break the generic test below?
+    if(!schema) {
+      if(builtinSchemaNames.indexOf(schemaName.name) >=0 ){
+        schema = this.symbols.schema[schemaName.name];
+      }
+    }
+    if (!schema) {
+      throw new Error(errors.noSuchType + schemaName);
+    }
+
+    if (ast.Schema.isGeneric(schema)) {
+      throw new Error(errors.noSuchType + schemaName + " used as non-generic type.");
+    }
+
+    return this.createValidatorFromSchema(schema, lSymbols);
+  }
+  createValidatorFromSchemaName(schemaName: string, lSymbols: ast.Symbols): Validator {
+    var schema = lSymbols.schema[schemaName];
 
     if (!schema) {
       throw new Error(errors.noSuchType + schemaName);
@@ -425,14 +468,14 @@ export class Generator {
       throw new Error(errors.noSuchType + schemaName + " used as non-generic type.");
     }
 
-    return this.createValidatorFromSchema(schema);
+    return this.createValidatorFromSchema(schema, lSymbols);
   }
 
-  createValidatorFromSchema(schema: ast.Schema): Validator {
+  createValidatorFromSchema(schema: ast.Schema, lSymbols: ast.Symbols): Validator {
     var hasProps = Object.keys(schema.properties).length > 0 &&
       !this.isCollectionSchema(schema);
 
-    if (hasProps && !this.symbols.isDerivedFrom(schema.derivedFrom, 'Object')) {
+    if (hasProps && !lSymbols.isDerivedFrom(schema.derivedFrom, 'Object')) {
       this.fatal(errors.nonObject + " (is " + ast.decodeExpression(schema.derivedFrom) + ")");
       return {};
     }
@@ -441,7 +484,7 @@ export class Generator {
 
     if (!(schema.derivedFrom.type === 'type' &&
           (<ast.ExpSimpleType> schema.derivedFrom).name === 'Any')) {
-      extendValidator(validator, this.ensureValidator(schema.derivedFrom));
+      extendValidator(validator, this.ensureValidator(schema.derivedFrom,lSymbols));
     }
 
     let requiredProperties = <string[]> [];
@@ -464,7 +507,7 @@ export class Generator {
       if (propName[0] !== '$' && !this.isNullableType(propType)) {
         requiredProperties.push(propName);
       }
-      extendValidator(<Validator> validator[propName], this.ensureValidator(propType));
+      extendValidator(<Validator> validator[propName], this.ensureValidator(propType,lSymbols));
     });
 
     if (wildProperties > 1 || wildProperties === 1 && requiredProperties.length > 0) {
@@ -500,8 +543,9 @@ export class Generator {
     var i: number;
     var location = <Validator> util.ensureObjectPath(this.rules, path.template.getLabels());
     var exp: ast.ExpValue;
+    var lSymbols = this.symbols;
 
-    extendValidator(location, this.ensureValidator(path.isType));
+    extendValidator(location, this.ensureValidator(path.isType,lSymbols));
     location['.scope'] = path.template.getScope();
 
     this.extendValidationMethods(location, path.methods);

--- a/src/rules-parser.pegjs
+++ b/src/rules-parser.pegjs
@@ -311,11 +311,14 @@ TypeExpression  = head:SingleType tail:(_ "|" _ type:SingleType { return type; }
 
 NamespacedIdentifier = namespace:(Identifier ".")? id:Identifier {
   if(namespace){
-    namespace = namespace[0];
-  }
-  return {
-    namespace: namespace,
-    id: id
+    return {
+      namespace: namespace[0],
+      id: id
+    }
+  } else {
+    return {
+      id: id
+    }
   }
 }
 

--- a/src/rules-parser.pegjs
+++ b/src/rules-parser.pegjs
@@ -84,7 +84,29 @@ start = _ Statements _ {
 
 Statements = rules:(Statement _)*
 
-Statement = f:Function / p:Path / s:Schema
+Statement = i:Import / f:Function / p:Path / s:Schema
+
+AliasName "aliasname definition" = "as" _ name:Identifier {
+  return name;
+}
+
+GlobalImport "global import" = "*" {
+  return [];
+}
+
+SpecificImports "specific import" = "{" _ identifiers:IdentifierList _ "}"
+{
+  return identifiers;
+}
+
+
+Import "import definition" = "import" _ identifiers:(GlobalImport / SpecificImports)? _ alias:(AliasName)? _"from" _"'" _ filePath:FilePath _ "'"  {
+  symbols.registerImport(identifiers, alias, filePath);
+}
+
+FilePath "file path" = start:[a-zA-Z\.] rest:([a-zA-Z_\.\\\/0-9\- ])+  {
+  return start + rest.join("");
+}
 
 Function "function definition" = func:FunctionStart body:FunctionBody? {
   if (func.name === null) {
@@ -287,19 +309,29 @@ TypeExpression  = head:SingleType tail:(_ "|" _ type:SingleType { return type; }
   return ast.unionType(tail);
 }
 
+NamespacedIdentifier = namespace:(Identifier ".")? id:Identifier {
+  if(namespace){
+    namespace = namespace[0];
+  }
+  return {
+    namespace: namespace,
+    id: id
+  }
+}
+
 // Type, Type[], or Type<X, ... >
 // where Type[] === Map<String, Type>
-SingleType = type:Identifier opt:("\[\]" {return {isMap: true}; }
+SingleType = type:NamespacedIdentifier opt:("\[\]" {return {isMap: true}; }
                                   / "<" _ types:TypeList ">" {return {types: types};})? _ {
-  type = ensureUpperCase(type, "Type names");
+  ensureUpperCase(type.id, "Type names");
   if (!opt) {
-    return ast.typeType(type);
+    return ast.typeTypeNamespaced(type.id, type.namespace);
   }
   if (opt.isMap) {
-    return ast.genericType('Map', [ast.typeType('String'),
-                                   ast.typeType(type)]);
+    return ast.genericType('Map', [ast.typeType('String', null),
+                                   ast.typeTypeNamespaced(type.id, type.namespace)]);
   }
-  return ast.genericType(type, opt.types);
+  return ast.genericType(type.id, opt.types);
 }
 
 TypeList = head:TypeExpression tail:(_ "," _ type:TypeExpression { return type; })* _ {

--- a/src/test/ast-test.ts
+++ b/src/test/ast-test.ts
@@ -15,10 +15,11 @@
  */
 import {assert} from 'chai';
 import * as helper from './test-helper';
-
 import * as bolt from '../bolt';
-let parse = bolt.parse;
 import * as ast from '../ast';
+
+let rulesParser = require('../rules-parser');
+let parse = rulesParser.parse;
 
 suite("Abstract Syntax Tree (AST)", function() {
   suite("Left Associative Operators (AND OR)", function() {

--- a/src/test/generator-test.ts
+++ b/src/test/generator-test.ts
@@ -183,7 +183,7 @@ suite("Rules Generator Tests", function() {
     helper.dataDrivenTest(tests, function(data, expect) {
       var symbols = parse("path / {}");
       var gen = new bolt.Generator(symbols);
-      gen.ensureValidator(ast.typeType(data));
+      gen.ensureValidator(ast.typeType(data), symbols);
 
       var terms = <ast.Exp[]> gen.validators[data]['.validate'];
       var result = bolt.decodeExpression(ast.andArray(terms));

--- a/src/test/parser-test.ts
+++ b/src/test/parser-test.ts
@@ -33,6 +33,56 @@ suite("Rules Parser Tests", function() {
     assert.ok(result instanceof ast.Symbols);
   });
 
+  suite("Imports", function(){
+    var tests = [
+      { data: "import * from 'foo'",
+        expect: {
+          filename: ast.string('foo') ,
+          alias: ast.string(''),
+          scope: ast.boolean(true)
+        }
+      },
+      { data: "import * from '../../foo/bar'",
+        expect: {
+          filename: ast.string('../../foo/bar'),
+          alias: ast.string(''),
+          scope: ast.boolean(false)
+        }
+      },
+      { data: "import {SomeType} from './foo/bar'",
+        expect: {
+          filename: ast.string('./foo/bar'),
+          alias: ast.string(''),
+          scope: ast.boolean(false)
+        }
+      },
+      { data: "import * as lol from './foo/bar'",
+        expect: {
+          filename: ast.string('./foo/bar'),
+          alias: ast.string('lol'),
+          scope: ast.boolean(false)
+        }
+      },
+      { data: "import {SomeType} as lol from './foo-bar'",
+        expect: {
+          filename: ast.string('./foo-bar'),
+          alias: ast.string('lol'),
+          scope: ast.boolean(false)
+        }
+      }
+    ];
+    helper.dataDrivenTest(tests, function(data, expect) {
+      console.log("******!!");
+      var result = parse(data);
+      console.log("******!!");
+      console.log(result);
+      assert.deepEqual(result.imports[0].filename, expect.filename.value);
+      assert.deepEqual(result.imports[0].alias, expect.alias.value);
+      assert.deepEqual(result.imports[0].scope, expect.scope.value);
+
+    });
+  });
+
   suite("Function Samples", function() {
     var tests: helper.ObjectSpec[] = [
       { data: "function f() { return true; }",

--- a/src/test/parser-test.ts
+++ b/src/test/parser-test.ts
@@ -37,49 +37,54 @@ suite("Rules Parser Tests", function() {
     var tests = [
       { data: "import * from 'foo'",
         expect: {
-          filename: ast.string('foo') ,
-          alias: ast.string(''),
-          scope: ast.boolean(true)
+          filename: ast.string('foo'),
+          alias: ast.nullType(),
+          identifiers: ast.array([])
         }
       },
       { data: "import * from '../../foo/bar'",
         expect: {
           filename: ast.string('../../foo/bar'),
-          alias: ast.string(''),
-          scope: ast.boolean(false)
+          alias: ast.nullType(),
+          identifiers: ast.array([])
         }
       },
       { data: "import {SomeType} from './foo/bar'",
         expect: {
           filename: ast.string('./foo/bar'),
-          alias: ast.string(''),
-          scope: ast.boolean(false)
+          alias: ast.nullType(),
+          identifiers: ast.array(['SomeType'])
         }
       },
       { data: "import * as lol from './foo/bar'",
         expect: {
           filename: ast.string('./foo/bar'),
           alias: ast.string('lol'),
-          scope: ast.boolean(false)
+          identifiers: ast.array([])
         }
       },
       { data: "import {SomeType} as lol from './foo-bar'",
         expect: {
           filename: ast.string('./foo-bar'),
           alias: ast.string('lol'),
-          scope: ast.boolean(false)
+          identifiers: ast.array(['SomeType'])
         }
       }
     ];
     helper.dataDrivenTest(tests, function(data, expect) {
-      console.log("******!!");
       var result = parse(data);
-      console.log("******!!");
-      console.log(result);
       assert.deepEqual(result.imports[0].filename, expect.filename.value);
-      assert.deepEqual(result.imports[0].alias, expect.alias.value);
-      assert.deepEqual(result.imports[0].scope, expect.scope.value);
+      assert.isArray(result.imports[0].identifiers);
+      assert.equal(result.imports[0].identifiers.length, expect.identifiers.value.length);
 
+      result.imports[0].identifiers.map( (x: any, index: number) => {
+        assert.deepEqual(expect.identifiers.value[index], x);
+      });
+      if (result.imports[0].alias) {
+       assert.deepEqual(result.imports[0].alias, expect.alias.value);
+     } else {
+       assert.isUndefined(expect.alias.value);
+     }
     });
   });
 


### PR DESCRIPTION
Allow for the importation of types:

import * from './module'
import * as types from './module'
import {Foo} from './module'

type Bar is Foo {

}

TODO: this is being pushed for review. Some more testing in the wild is still happening.