### PR TITLE
allow wildcard properties in type statement

### DIFF
--- a/docs/language.md
+++ b/docs/language.md
@@ -31,6 +31,7 @@ A (user-defined) type statement describes a value that can be stored in the Fire
 type MyType [extends BaseType] {
   property1: Type,
   property2: Type,
+  $wildcardProp: Type
   ...
 
   validate() { <validation expression> }
@@ -54,6 +55,12 @@ Property names in type statements should be valid Identifiers (see below).  If y
 to use any other character in a property name, you can enclose them in quotes (note
 that Firebase allows any character in a path *except* for `.`, `$`, `#`, `[`, `[`, `/`,
 or control characters).
+
+When a type statement contains a wildcard property, i.e. a property starting with the 
+`$`-character, the value is allowed to have an arbitrary number of extra properties. When
+there is no wildcard property, the value can only have the properties defined in the
+type statement. A type can have at most one wildcard property.
+
 
 Built-in base types are also similar to JavaScript types:
 

--- a/samples/issue-212.bolt
+++ b/samples/issue-212.bolt
@@ -1,0 +1,40 @@
+type MyType {
+  num: Number;
+  str: String;
+  any: Any;
+  $extras: Any;
+}
+
+type AnyMap {
+  $extras: Any;
+}
+
+type OtherType extends AnyMap {
+  name: String;
+}
+
+type WithExtras<T> extends T {
+  $extras: Any;
+}
+
+type AnotherType {
+  name: String;
+}
+
+
+path /path is MyType {
+  read() { true }
+  write() { true }
+}
+
+path /other is OtherType {
+  read() { true }
+}
+
+path /another is AnotherType {
+  read() { true }
+}
+
+path /anotherWithExtras is WithExtras<AnotherType> {
+  read() { true }
+}

--- a/samples/issue-212.json
+++ b/samples/issue-212.json
@@ -1,0 +1,42 @@
+{
+  "rules": {
+    "path": {
+      ".validate": "newData.hasChildren(['num', 'str', 'any'])",
+      "num": {
+        ".validate": "newData.isNumber()"
+      },
+      "str": {
+        ".validate": "newData.isString()"
+      },
+      "any": {
+        ".validate": "true"
+      },
+      ".read": "true",
+      ".write": "true"
+    },
+    "other": {
+      ".validate": "newData.hasChildren(['name'])",
+      "name": {
+        ".validate": "newData.isString()"
+      },
+      ".read": "true"
+    },
+    "another": {
+      ".validate": "newData.hasChildren(['name'])",
+      "name": {
+        ".validate": "newData.isString()"
+      },
+      "$other": {
+        ".validate": "false"
+      },
+      ".read": "true"
+    },
+    "anotherWithExtras": {
+      ".validate": "newData.hasChildren(['name'])",
+      "name": {
+        ".validate": "newData.isString()"
+      },
+      ".read": "true"
+    }
+  }
+}

--- a/src/rules-generator.ts
+++ b/src/rules-generator.ts
@@ -448,6 +448,7 @@ export class Generator {
     let wildProperties = 0;
     Object.keys(schema.properties).forEach((propName) => {
       if (propName[0] === '$') {
+        delete validator.$other;
         wildProperties += 1;
         if (INVALID_KEY_REGEX.test(propName.slice(1))) {
           this.fatal(errors.invalidPropertyName + propName);
@@ -467,7 +468,7 @@ export class Generator {
       extendValidator(<Validator> validator[propName], this.ensureValidator(propType));
     });
 
-    if (wildProperties > 1 || wildProperties === 1 && requiredProperties.length > 0) {
+    if (wildProperties > 1) {
       this.fatal(errors.invalidWildChildren);
     }
 
@@ -478,7 +479,11 @@ export class Generator {
     }
 
     // Disallow $other properties by default
-    if (hasProps) {
+    let hasWildProps = Object.keys(validator).some((v) => {
+        return v[0] === '$';
+    });
+
+    if (hasProps && !hasWildProps ) {
       validator['$other'] = {};
       extendValidator(<Validator> validator['$other'],
                       <Validator> {'.validate': ast.boolean(false)});

--- a/src/test/sample-files.ts
+++ b/src/test/sample-files.ts
@@ -13,6 +13,7 @@ export let samples = [
   "issue-169",
   "issue-232",
   "issue-97",
+  "issue-212",
   "mail",
   "map-scalar",
   "multi-update",


### PR DESCRIPTION
Currently it is not allowed to have both wildcard properties and fields. Therefore, it is not possible to define types that allow properties other than the ones defined in the type statement. Only workaround is to not use type statements and manually define the validate rules, which is very cumbersome. See also issues #212 and #213 .

This pull request allows a single wildcard property inside a type definition and when present disables the generation of the default validation rule that does not allow any field other than the ones defined.